### PR TITLE
更新图文消息方法Media::updateNews()与微信API不一致

### DIFF
--- a/src/Wechat/Media.php
+++ b/src/Wechat/Media.php
@@ -176,7 +176,7 @@ class Media
         $params = array(
                    'media_id' => $mediaId,
                    'index'    => $index,
-                   'articles' => array($article),
+                   'articles' => isset($article['title']) ? $article : (isset($article[$index]) ? $article[$index] : array()),
                   );
 
         return $this->http->jsonPost(self::API_FOREVER_NEWS_UPDATE, $params);


### PR DESCRIPTION
关联issue #29 
如果可以预见客户端传入参数错了，直接扔空数组让微信报错（还浪费一次API配额哈哈）