### PR TITLE
支持自定义菜单类型：下发消息media_id、跳转图文消息view_limited

### DIFF
--- a/src/Wechat/MenuItem.php
+++ b/src/Wechat/MenuItem.php
@@ -40,7 +40,18 @@ class MenuItem extends MagicAttributes
         $type !== null && $this->with('type', $type);
 
         if ($property !== null) {
-            $key = ($type === 'view') ? 'url' : 'key';
+            switch($type){
+                case 'view':
+                    $key = 'url';
+                    break;
+                case 'media_id':
+                    // no break
+                case 'view_limited':
+                    $key = 'media_id';
+                    break;
+                default:
+                    $key = 'key';
+            }
             $this->with($key, $property);
         }
     }


### PR DESCRIPTION
http://mp.weixin.qq.com/wiki/13/43de8269be54a0a6f64413e4dfa94f39.html
存在两个暂未支持的自定义菜单类型：
`media_id`	`media_id`类型和`view_limited`类型必须	调用新增永久素材接口返回的合法media_id

用`click`和`view`类型事件实现下发和跳转也不错，但有些不需要跟踪和动态回复的菜单项更适合用类似微信自带的菜单管理来实现。建议加入支持，谢谢。