### PR TITLE
Fixed StyleCI config

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,10 +1,11 @@
 preset: symfony
 
 enabled:
+  - align_equals
   - strict
   - strict_param
-  - align_equals
 
 disabled:
-  - short_array_syntax
   - phpdoc_short_description
+  - short_array_syntax
+  - unalign_equals

--- a/.styleci.yml
+++ b/.styleci.yml
@@ -7,5 +7,4 @@ enabled:
 
 disabled:
   - phpdoc_short_description
-  - short_array_syntax
   - unalign_equals


### PR DESCRIPTION
Hi there. I just noticed your repo was failing with the following messages:

```
The provided fixer 'unalign_equals' cannot be enabled at the same time as 'align_equals'.
The provided fixer 'short_array_syntax' cannot be disabled unless it was already enabled by your preset.
```

For reference, all our config docs are available at https://styleci.readme.io/docs/configuration.