### PR TITLE
accessToken根据appId变化

### DIFF
--- a/src/Wechat/AccessToken.php
+++ b/src/Wechat/AccessToken.php
@@ -69,6 +69,7 @@ class AccessToken
     {
         $this->appId     = $appId;
         $this->appSecret = $appSecret;
+        $this->cacheKey = $this->cacheKey.'.'.$appId;
         $this->cache     = new Cache($appId);
     }
 


### PR DESCRIPTION
开发一个公众号项目，需要绑定多个公众号，然而发现缓存access_token时用的key是固定的，多个公众号就会相互覆盖access_token ，所以讲appId加入到cacheKey中应该是合理的。