### PR TITLE
AccessToken类添加refreshToken方法，用于强制重新获取access_token

### DIFF
--- a/src/Wechat/AccessToken.php
+++ b/src/Wechat/AccessToken.php
@@ -119,4 +119,31 @@ class AccessToken
             }
         );
     }
+
+    /**
+     * 刷新Token
+     *
+     * @return string
+     */
+    public function refreshToken()
+    {
+        $appId       = $this->appId;
+        $appSecret   = $this->appSecret;
+        $cache       = $this->cache;
+        $cacheKey    = $this->cacheKey;
+        $apiTokenGet = self::API_TOKEN_GET;
+
+        $params = array(
+            'appid'      => $appId,
+            'secret'     => $appSecret,
+            'grant_type' => 'client_credential',
+        );
+        $http = new Http();
+
+        $token = $http->get($apiTokenGet, $params);
+
+        $cache->set($cacheKey, $token['access_token'], $token['expires_in'] - 1500);
+
+        return $token['access_token'];
+    }
 }


### PR DESCRIPTION
AccessToken添加了refreshToken方法，当操蛋的accessToken提前失效的情况发生时可用其重新拉取accessToken并更新本地缓存