### PR TITLE
修改SDK读取原始post数据的方法

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ index.php
 getcode.php
 showlink.php
 *.jpg
+
+
+#project file
+.idea

--- a/src/Wechat/Payment/Notify.php
+++ b/src/Wechat/Payment/Notify.php
@@ -47,7 +47,7 @@ class Notify
      * @return bool|Bag
      */
     public function verify() {
-        $xmlInput = Http::rawData();
+        $xmlInput = Http::rawInput();
 
         if (empty($xmlInput)) {
             return false;

--- a/src/Wechat/Payment/Notify.php
+++ b/src/Wechat/Payment/Notify.php
@@ -16,6 +16,7 @@
 
 namespace Overtrue\Wechat\Payment;
 
+use Overtrue\Wechat\Utils\Http;
 use Overtrue\Wechat\Utils\XML;
 use Overtrue\Wechat\Utils\Bag;
 use Overtrue\Wechat\Utils\SignGenerator;
@@ -46,15 +47,7 @@ class Notify
      * @return bool|Bag
      */
     public function verify() {
-        if (version_compare(PHP_VERSION, '5.6.0', '<')) {
-            if (!empty($GLOBALS['HTTP_RAW_POST_DATA'])) {
-                $xmlInput = $GLOBALS['HTTP_RAW_POST_DATA'];
-            } else {
-                $xmlInput = file_get_contents('php://input');
-            }
-        } else {
-            $xmlInput = file_get_contents('php://input');
-        }
+        $xmlInput = Http::rawData();
 
         if (empty($xmlInput)) {
             return false;

--- a/src/Wechat/Server.php
+++ b/src/Wechat/Server.php
@@ -190,7 +190,7 @@ class Server
             return;
         }
 
-        $xmlInput = Http::rawData();
+        $xmlInput = Http::rawInput();
 
         if(empty($_REQUEST['echostr']) && empty($xmlInput) && !empty($_REQUEST['signature'])) {
             throw new Exception("没有读取到消息 XML，请在 php.ini 中打开 always_populate_raw_post_data=On", 500);

--- a/src/Wechat/Server.php
+++ b/src/Wechat/Server.php
@@ -192,7 +192,7 @@ class Server
 
         $xmlInput = Http::rawData();
 
-        if(empty($xmlInput) && empty($_REQUEST['echostr']) && empty($xmlInput) && !empty($_REQUEST['signature'])) {
+        if(empty($_REQUEST['echostr']) && empty($xmlInput) && !empty($_REQUEST['signature'])) {
             throw new Exception("没有读取到消息 XML，请在 php.ini 中打开 always_populate_raw_post_data=On", 500);
         }
 

--- a/src/Wechat/Server.php
+++ b/src/Wechat/Server.php
@@ -17,6 +17,7 @@ namespace Overtrue\Wechat;
 
 use Overtrue\Wechat\Messages\BaseMessage;
 use Overtrue\Wechat\Utils\Bag;
+use Overtrue\Wechat\Utils\Http;
 use Overtrue\Wechat\Utils\XML;
 
 /**
@@ -189,18 +190,10 @@ class Server
             return;
         }
 
-        if (version_compare(PHP_VERSION, '5.6.0', '<')) {
-            if (!empty($GLOBALS['HTTP_RAW_POST_DATA'])) {
-                $xmlInput = $GLOBALS['HTTP_RAW_POST_DATA'];
-            } else {
-                $xmlInput = file_get_contents('php://input');
-            }
+        $xmlInput = Http::rawData();
 
-            if (empty($_REQUEST['echostr']) && empty($xmlInput) && !empty($_REQUEST['signature'])) {
-                throw new Exception("没有读取到消息 XML，请在 php.ini 中打开 always_populate_raw_post_data=On", 500);
-            }
-        } else {
-            $xmlInput = file_get_contents('php://input');
+        if(empty($xmlInput) && empty($_REQUEST['echostr']) && empty($xmlInput) && !empty($_REQUEST['signature'])) {
+            throw new Exception("没有读取到消息 XML，请在 php.ini 中打开 always_populate_raw_post_data=On", 500);
         }
 
         $input = XML::parse($xmlInput);

--- a/src/Wechat/Utils/Http.php
+++ b/src/Wechat/Utils/Http.php
@@ -300,12 +300,15 @@ class Http
      * http://php.net/manual/zh/wrappers.php.php
      * @return null|string
      */
-    public static function rawData(){
+    public static function rawInput()
+    {
         $content = null;
+
         if ($content = file_get_contents('php://input')) {
         } elseif (!empty($GLOBALS['HTTP_RAW_POST_DATA'])) {
             $content = $GLOBALS['HTTP_RAW_POST_DATA'];
         }
+
         return $content;
     }
 }

--- a/src/Wechat/Utils/Http.php
+++ b/src/Wechat/Utils/Http.php
@@ -294,4 +294,18 @@ class Http
 
         return $results;
     }
+
+    /**
+     * 获取请求的post数据
+     * http://php.net/manual/zh/wrappers.php.php
+     * @return null|string
+     */
+    public static function rawData(){
+        $content = null;
+        if ($content = file_get_contents('php://input')) {
+        } elseif (!empty($GLOBALS['HTTP_RAW_POST_DATA'])) {
+            $content = $GLOBALS['HTTP_RAW_POST_DATA'];
+        }
+        return $content;
+    }
 }


### PR DESCRIPTION
在Server::prepareInput中，原来的从POST读取原始请求数据的实现会先判断PHP版本然后进行从php://input或者$GLOBALS['HTTP_RAW_POST_DATA']中读取数据，但是PHP的版本不会影响php://input，所以这个地方判断版本是没有意义的。而且应该先从php://input读取，再从$GLOBALS['HTTP_RAW_POST_DATA']读取，因为$GLOBALS['HTTP_RAW_POST_DATA']依赖于php.ini的配置。

其次就是我把从POST读取原始请求数据的逻辑放在了Http中作为静态方法。