### PR TITLE
fix Js.php 获取自定义cache对象

### DIFF
--- a/src/Js/Js.php
+++ b/src/Js/Js.php
@@ -205,6 +205,6 @@ class Js extends AbstractAPI
      */
     public function getCache()
     {
-        return $this->cache ?: $this->cache = new Cache();
+        return $this->cache ?: $this->cache = $this->getAccessToken()->getCache();
     }
 }


### PR DESCRIPTION
如果自定义缓存类，Js.php默认未被注册自定义cache对象
$app['cache']->setAdapter(new RedisAdapter());
public function getCache()
    {
        return $this->cache ?: $this->cache = $this->getAccessToken()->getCache();
    }
