### PR TITLE
Multiple News Items support

### DIFF
--- a/src/Message/News.php
+++ b/src/Message/News.php
@@ -51,4 +51,25 @@ class News extends AbstractMessage
     protected $aliases = [
         'image' => 'pic_url',
     ];
+    
+    /**
+     * News constructor.
+     * @param array $items
+     */
+    public function __construct(array $items = [])
+    {
+        if(!empty($items)){
+            if(!is_array(current($items))){
+                //single item
+                parent::__construct($items);
+            }else{
+                //multiple items
+                foreach($items as $item){
+                    if(!empty($item)){
+                        array_push($this->items,new News($item));
+                    }
+                }
+            }
+        }
+    }
 }

--- a/src/Server/Transformer.php
+++ b/src/Server/Transformer.php
@@ -137,15 +137,11 @@ class Transformer
      *
      * @return array
      */
-    public function transformNews($news)
+    public function transformNews(AbstractMessage $news)
     {
         $articles = [];
 
-        if (!is_array($news)) {
-            $news = [$news];
-        }
-
-        foreach ($news as $item) {
+        foreach ($news->all() as $item) {
             $articles[] = [
                            'Title' => $item->title,
                            'Description' => $item->description,

--- a/src/Server/Transformer.php
+++ b/src/Server/Transformer.php
@@ -133,7 +133,7 @@ class Transformer
     /**
      * Transform news message.
      *
-     * @param array|EasyWeChat\Message\News $news
+     * @param EasyWeChat\Message\News $news
      *
      * @return array
      */


### PR DESCRIPTION
            return new News([
                [
                    'title'=> 'Title Demo1',
                    'description'=> 'Description Demo1',
                    'url' => 'Url Demo1',
                    'image'=> 'Image Url Demo1',
                ],
                [
                    'title'=> 'Title Demo2',
                    'description'=> 'Description Demo2',
                    'url' => 'Url Demo2',
                    'image'=> 'Image Url Demo2',
                ]
            ]);

or

            return new News([
                'title'=> 'Title Demo1',
                'description'=> 'Description Demo1',
                'url' => 'Url Demo1',
                'image'=> 'Image Url Demo1',
            ]);