### PR TITLE
added method for app payment

### DIFF
--- a/src/Payment/Payment.php
+++ b/src/Payment/Payment.php
@@ -139,6 +139,29 @@ class Payment
     }
 
     /**
+     * Generate app payment parameters.
+     *
+     * @param string $prepayId
+     *
+     * @return array
+     */
+    public function configForAppPayment($prepayId)
+    {
+        $params = [
+            'appid' => $this->merchant->app_id,
+            'partnerid' => $this->merchant->merchant_id,
+            'prepayid' => $prepayId,
+            'noncestr' => uniqid(),
+            'timestamp' => time(),
+            'package' => 'Sign=WXPay',
+        ];
+
+        $params['sign'] = generate_sign($params, $this->merchant->key);
+
+        return $params;
+    }
+
+    /**
      * Generate js config for share user address.
      *
      * @param string|accessToken $accessToken

--- a/tests/Payment/PaymentPaymentTest.php
+++ b/tests/Payment/PaymentPaymentTest.php
@@ -134,6 +134,23 @@ class PaymentPaymentTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * test configForAppPayment.
+     */
+    public function testConfigForAppPayment()
+    {
+        $payment = $this->getPayment();
+
+        $array = $payment->configForAppPayment('prepayId');
+
+        $this->assertEquals('wxTestAppId', $array['appid']);
+        $this->assertEquals('prepayId', $array['prepayid']);
+        $this->assertEquals('Sign=WXPay', $array['package']);
+        $this->assertArrayHasKey('timestamp', $array);
+        $this->assertArrayHasKey('noncestr', $array);
+        $this->assertArrayHasKey('sign', $array);
+    }
+
+    /**
      * test configForShareAddress.
      */
     public function testConfigForShareAddress()


### PR DESCRIPTION
The new method is based on the document and tested in our env.

The document is https://pay.weixin.qq.com/wiki/doc/api/app.php?chapter=9_12
```
Changes to be committed:
	modified:   src/Payment/Payment.php
	modified:   tests/Payment/PaymentPaymentTest.php
```