### PR TITLE
删除裂变红包接口中的ip参数

### DIFF
--- a/src/Payment/LuckyMoney/API.php
+++ b/src/Payment/LuckyMoney/API.php
@@ -144,7 +144,6 @@ class API extends AbstractAPI
     public function sendGroup($params)
     {
         $params['amt_type'] = 'ALL_RAND';
-        $params['client_ip'] = !empty($params['client_ip']) ? $params['client_ip'] : $_SERVER['HTTP_CLIENT_IP'];
 
         return $this->send($params, self::TYPE_GROUP);
     }


### PR DESCRIPTION
裂变红包发送接口中不需要`client_ip`参数，包含此参数时会出现签名错误，导致红包无法发送。