### PR TITLE
add payment default notify_url.

### DIFF
--- a/src/Payment/API.php
+++ b/src/Payment/API.php
@@ -81,6 +81,7 @@ class API extends AbstractAPI
      */
     public function pay(Order $order)
     {
+        $order['notify_url'] = $order['notify_url']?:$this->merchat->notify_url;
         return $this->request(self::API_PAY_ORDER, $order->all());
     }
 
@@ -93,6 +94,7 @@ class API extends AbstractAPI
      */
     public function prepare(Order $order)
     {
+        $order['notify_url'] = $order['notify_url']?:$this->merchat->notify_url;
         return $this->request(self::API_PREPARE_ORDER, $order->all());
     }
 


### PR DESCRIPTION
$options = [
    // ...
    'payment' => [
        // ...
        'notify_url' => 'http://xxx.com/order-notify'
    ]
];
$app = new Application($options);
$attributes = [
    // ...
    'notify_url'       => 'http://xxx.com/order-notify',

];
$order = new Order($attributes);

if $order haven't notify_url attribute, use $options['payment']['notify_url']. Don't need to be set notify_url in every order.