### PR TITLE
刷卡支付不需要notify_url参数

### DIFF
--- a/src/Payment/API.php
+++ b/src/Payment/API.php
@@ -81,8 +81,6 @@ class API extends AbstractAPI
      */
     public function pay(Order $order)
     {
-        $order->notify_url = $order->get('notify_url', $this->merchant->notify_url);
-
         return $this->request(self::API_PAY_ORDER, $order->all());
     }
 


### PR DESCRIPTION
刷卡支付不需要notify_url参数

```json
{"return_code":"FAIL","return_msg":"不识别的参数notify_url"}
```