### PR TITLE
增加微信支付服务商支持

### DIFF
--- a/src/Payment/API.php
+++ b/src/Payment/API.php
@@ -367,6 +367,26 @@ class API extends AbstractAPI
     }
 
     /**
+     * Add Params If Wechat Payment Service Provider.
+     *
+     * @param array $params
+     *
+     * @return array
+     */
+    public function addIfServiceProvider(array $params)
+    {
+        if($this->merchant->has('sub_app_id')) {
+            $params['sub_appid'] = $this->merchant->get('sub_app_id');
+        }
+
+        if($this->merchant->has('sub_merchant_id')) {
+            $params['sub_mch_id'] = $this->merchant->get('sub_merchant_id');
+        }
+
+        return $params;
+    }
+
+    /**
      * Make a API request.
      *
      * @param string $api
@@ -379,6 +399,8 @@ class API extends AbstractAPI
      */
     protected function request($api, array $params, $method = 'post', array $options = [], $returnResponse = false)
     {
+        $params = $this->addIfServiceProvider($params);
+        
         $params['appid'] = $this->merchant->app_id;
         $params['mch_id'] = $this->merchant->merchant_id;
         $params['device_info'] = $this->merchant->device_info;

--- a/src/Payment/API.php
+++ b/src/Payment/API.php
@@ -367,26 +367,6 @@ class API extends AbstractAPI
     }
 
     /**
-     * Add Params If Wechat Payment Service Provider.
-     *
-     * @param array $params
-     *
-     * @return array
-     */
-    public function addIfServiceProvider(array $params)
-    {
-        if ($this->merchant->has('sub_app_id')) {
-            $params['sub_appid'] = $this->merchant->get('sub_app_id');
-        }
-
-        if ($this->merchant->has('sub_merchant_id')) {
-            $params['sub_mch_id'] = $this->merchant->get('sub_merchant_id');
-        }
-
-        return $params;
-    }
-
-    /**
      * Make a API request.
      *
      * @param string $api
@@ -399,7 +379,7 @@ class API extends AbstractAPI
      */
     protected function request($api, array $params, $method = 'post', array $options = [], $returnResponse = false)
     {
-        $params = $this->addIfServiceProvider($params);
+        $params = array_merge($params, $this->merchant->only(['sub_appid', 'sub_mch_id']));
 
         $params['appid'] = $this->merchant->app_id;
         $params['mch_id'] = $this->merchant->merchant_id;

--- a/src/Payment/API.php
+++ b/src/Payment/API.php
@@ -375,11 +375,11 @@ class API extends AbstractAPI
      */
     public function addIfServiceProvider(array $params)
     {
-        if($this->merchant->has('sub_app_id')) {
+        if ($this->merchant->has('sub_app_id')) {
             $params['sub_appid'] = $this->merchant->get('sub_app_id');
         }
 
-        if($this->merchant->has('sub_merchant_id')) {
+        if ($this->merchant->has('sub_merchant_id')) {
             $params['sub_mch_id'] = $this->merchant->get('sub_merchant_id');
         }
 
@@ -400,7 +400,7 @@ class API extends AbstractAPI
     protected function request($api, array $params, $method = 'post', array $options = [], $returnResponse = false)
     {
         $params = $this->addIfServiceProvider($params);
-        
+
         $params['appid'] = $this->merchant->app_id;
         $params['mch_id'] = $this->merchant->merchant_id;
         $params['device_info'] = $this->merchant->device_info;

--- a/src/Payment/Merchant.php
+++ b/src/Payment/Merchant.php
@@ -61,6 +61,8 @@ class Merchant extends Attribute
         'app_id' => 'appid',
         'key' => 'mch_key',
         'merchant_id' => 'mch_id',
+        'sub_app_id' => 'sub_appid',
+        'sub_merchant_id' => 'sub_mch_id',
         'cert_path' => 'sslcert_path',
         'key_path' => 'sslkey_path',
     ];


### PR DESCRIPTION
因当前版本微信支付服务商支持不完整，需要每次在微信支付 attributes 中加入子公众号 `sub_appid` & `sub_mch_id`，现改成全局支持（若设置）

- 增加微信支付服务商子公众号参数别名声明 `sub_app_id` => `sub_appid` 和 `sub_merchant_id` => `sub_mch_id`
- 增加请求前增加微信支付服务商参数 `sub_appid` & `sub_mch_id` 的支持