### PR TITLE
NGINX HTTPS无法签名

### DIFF
--- a/src/Support/Url.php
+++ b/src/Support/Url.php
@@ -34,7 +34,7 @@ class Url
     {
         $protocol = (!empty($_SERVER['HTTPS'])
                         && $_SERVER['HTTPS'] !== 'off'
-                        || $_SERVER['SERVER_PORT'] === 443) ? 'https://' : 'http://';
+                        || (int)$_SERVER['SERVER_PORT'] === 443) ? 'https://' : 'http://';
 
         return $protocol.$_SERVER['HTTP_HOST'].$_SERVER['REQUEST_URI'];
     }


### PR DESCRIPTION
判断协议的地方有类型bug，vardump($_SERVER['SERVER_PORT'])在我这边是string类型。