### PR TITLE
Add AccessToen Cache Config

### DIFF
--- a/src/Foundation/Application.php
+++ b/src/Foundation/Application.php
@@ -23,7 +23,6 @@
  * @link      https://github.com/overtrue/wechat
  * @link      http://overtrue.me
  */
-
 namespace EasyWeChat\Foundation;
 
 use Doctrine\Common\Cache as CacheInterface;

--- a/src/Foundation/Application.php
+++ b/src/Foundation/Application.php
@@ -23,6 +23,7 @@
  * @link      https://github.com/overtrue/wechat
  * @link      http://overtrue.me
  */
+
 namespace EasyWeChat\Foundation;
 
 use Doctrine\Common\Cache\FilesystemCache;
@@ -196,14 +197,14 @@ class Application extends Container
             return Request::createFromGlobals();
         };
 
-        if(empty($this['config']['cache'])) {
+        if (empty($this['config']['cache'])) {
             $this['cache'] = function () {
                 return new FilesystemCache(sys_get_temp_dir());
             };
         } else {
             $this['cache'] = $this['config']['cache'];
         }
-        
+
         $this['access_token'] = function () {
             return new AccessToken(
                $this['config']['app_id'],

--- a/src/Foundation/Application.php
+++ b/src/Foundation/Application.php
@@ -25,7 +25,7 @@
  */
 namespace EasyWeChat\Foundation;
 
-use Doctrine\Common\Cache as CacheInterface;
+use Doctrine\Common\Cache\Cache as CacheInterface;
 use Doctrine\Common\Cache\FilesystemCache;
 use EasyWeChat\Core\AccessToken;
 use EasyWeChat\Core\Http;

--- a/src/Foundation/Application.php
+++ b/src/Foundation/Application.php
@@ -196,10 +196,14 @@ class Application extends Container
             return Request::createFromGlobals();
         };
 
-        $this['cache'] = function () {
-            return new FilesystemCache(sys_get_temp_dir());
-        };
-
+        if(empty($this['config']['cache'])) {
+            $this['cache'] = function () {
+                return new FilesystemCache(sys_get_temp_dir());
+            };
+        } else {
+            $this['cache'] = $this['config']['cache'];
+        }
+        
         $this['access_token'] = function () {
             return new AccessToken(
                $this['config']['app_id'],

--- a/src/Foundation/Application.php
+++ b/src/Foundation/Application.php
@@ -26,6 +26,7 @@
 
 namespace EasyWeChat\Foundation;
 
+use Doctrine\Common\Cache\CacheProvider;
 use Doctrine\Common\Cache\FilesystemCache;
 use EasyWeChat\Core\AccessToken;
 use EasyWeChat\Core\Http;
@@ -197,7 +198,7 @@ class Application extends Container
             return Request::createFromGlobals();
         };
 
-        if (empty($this['config']['cache'])) {
+        if (!empty($this['config']['cache']) && $this['config']['cache'] instanceof CacheProvider) {
             $this['cache'] = function () {
                 return new FilesystemCache(sys_get_temp_dir());
             };

--- a/src/Foundation/Application.php
+++ b/src/Foundation/Application.php
@@ -198,11 +198,11 @@ class Application extends Container
         };
 
         if (!empty($this['config']['cache']) && $this['config']['cache'] instanceof CacheInterface) {
+            $this['cache'] = $this['config']['cache'];
+        } else {
             $this['cache'] = function () {
                 return new FilesystemCache(sys_get_temp_dir());
             };
-        } else {
-            $this['cache'] = $this['config']['cache'];
         }
 
         $this['access_token'] = function () {

--- a/src/Foundation/Application.php
+++ b/src/Foundation/Application.php
@@ -23,9 +23,10 @@
  * @link      https://github.com/overtrue/wechat
  * @link      http://overtrue.me
  */
+
 namespace EasyWeChat\Foundation;
 
-use Doctrine\Common\Cache\CacheProvider;
+use Doctrine\Common\Cache as CacheInterface;
 use Doctrine\Common\Cache\FilesystemCache;
 use EasyWeChat\Core\AccessToken;
 use EasyWeChat\Core\Http;
@@ -197,7 +198,7 @@ class Application extends Container
             return Request::createFromGlobals();
         };
 
-        if (!empty($this['config']['cache']) && $this['config']['cache'] instanceof CacheProvider) {
+        if (!empty($this['config']['cache']) && $this['config']['cache'] instanceof CacheInterface) {
             $this['cache'] = function () {
                 return new FilesystemCache(sys_get_temp_dir());
             };

--- a/src/Foundation/Application.php
+++ b/src/Foundation/Application.php
@@ -23,7 +23,6 @@
  * @link      https://github.com/overtrue/wechat
  * @link      http://overtrue.me
  */
-
 namespace EasyWeChat\Foundation;
 
 use Doctrine\Common\Cache\CacheProvider;


### PR DESCRIPTION
可实现在实例化`Application`的时候配置AccessToken缓存方式

示例：
```
        $cache = new RedisCache();

        // 创建 redis 实例
        $redis = new Redis();
        $redis->connect('redis_host', 6379);

        $cache->setRedis($redis);
        $options = [
            'debug'  => false,
            'app_id' => $wechatInfo['app_id'],
            'secret' => $wechatInfo['app_secret'],
            'token'  => $wechatInfo['token'],
            'aes_key' => $wechatInfo['aes_key'], // 可选
            'cache'   => $cache,
        ];

        $wechatApp = new Application($options);
```

Signed-off-by: dingdayu <614422099@qq.com>