### PR TITLE
Update XML.php

### DIFF
--- a/src/Support/XML.php
+++ b/src/Support/XML.php
@@ -100,7 +100,7 @@ class XML
         $result = null;
 
         if (is_object($obj)) {
-            $obj = get_object_vars($obj);
+            $obj = (array)$obj;
         }
 
         if (is_array($obj)) {


### PR DESCRIPTION
HHVM不支持对XML，simplexml_load_string 后 再 get_object_vars，会直接返回空数组。
推荐使用老方法(array)， PHP支持，HHVM也支持，何乐而不为。