### PR TITLE
修复 with 方法带数据的问题

### DIFF
--- a/src/Core/AccessToken.php
+++ b/src/Core/AccessToken.php
@@ -104,7 +104,8 @@ class AccessToken
      */
     public function getToken($forceRefresh = false)
     {
-        $cached = $this->getCache()->fetch($this->getCacheKey());
+        $cacheKey = $this->getCacheKey();
+        $cached = $this->getCache()->fetch($cacheKey);
 
         if ($forceRefresh || empty($cached)) {
             $token = $this->getTokenFromServer();

--- a/src/Core/AccessToken.php
+++ b/src/Core/AccessToken.php
@@ -278,7 +278,7 @@ class AccessToken
     /**
      * Get access token cache key.
      *
-     * @return string Cache key.
+     * @return string $this->cacheKey
      */
     public function getCacheKey()
     {

--- a/src/Core/AccessToken.php
+++ b/src/Core/AccessToken.php
@@ -51,6 +51,13 @@ class AccessToken
     protected $cache;
 
     /**
+     * Cache Key.
+     *
+     * @var cacheKey
+     */
+    protected $cacheKey;
+
+    /**
      * Http instance.
      *
      * @var Http
@@ -97,9 +104,7 @@ class AccessToken
      */
     public function getToken($forceRefresh = false)
     {
-        $cacheKey = $this->prefix.$this->appId;
-
-        $cached = $this->getCache()->fetch($cacheKey);
+        $cached = $this->getCache()->fetch($this->getCacheKey());
 
         if ($forceRefresh || empty($cached)) {
             $token = $this->getTokenFromServer();
@@ -239,5 +244,47 @@ class AccessToken
         $this->http = $http;
 
         return $this;
+    }
+
+    /**
+     * Set the access token prefix.
+     *
+     * @param string $prefix
+     *
+     * @return $this
+     */
+    public function setPrefix($prefix)
+    {
+        $this->prefix = $prefix;
+
+        return $this;
+    }
+
+    /**
+     * Set access token cache key.
+     *
+     * @param string $prefix
+     *
+     * @return $this
+     */
+    public function setCacheKey($cacheKey)
+    {
+        $this->cacheKey = $cacheKey;
+
+        return $this;
+    }
+
+    /**
+     * Get access token cache key.
+     *
+     * @return string Cache key.
+     */
+    public function getCacheKey()
+    {
+        if (is_null($this->cacheKey)) {
+            return $this->prefix.$this->appId;
+        }
+
+        return $this->cacheKey;
     }
 }

--- a/src/Core/AccessToken.php
+++ b/src/Core/AccessToken.php
@@ -264,7 +264,7 @@ class AccessToken
     /**
      * Set access token cache key.
      *
-     * @param string $prefix
+     * @param string $cacheKey
      *
      * @return $this
      */

--- a/src/Notice/Notice.php
+++ b/src/Notice/Notice.php
@@ -200,7 +200,7 @@ class Notice extends AbstractAPI
                 'with' => 'data',
                ];
 
-        if (0 === stripos($method, 'with')) {
+        if (0 === stripos($method, 'with') && strlen($method) > 4) {
             $method = lcfirst(substr($method, 4));
         }
 


### PR DESCRIPTION
``` php
app('wechat')->notice->with($data);
```

从接口预留上看这种方式可用，但是 `isset($map[$method])` 的判断 `$method` 就成了空字符串。