### PR TITLE
修复 with 方法带数据的问题

### DIFF
--- a/src/Notice/Notice.php
+++ b/src/Notice/Notice.php
@@ -200,7 +200,7 @@ class Notice extends AbstractAPI
                 'with' => 'data',
                ];
 
-        if (0 === stripos($method, 'with')) {
+        if (0 === stripos($method, 'with') && strlen($method) > 4) {
             $method = lcfirst(substr($method, 4));
         }
 


### PR DESCRIPTION
从接口预留上看：
```php
app('wechat')->notice->with($data)
```
这种调用是可用的。

但是下面的判断和截取会导致 `isset($map[$method])` 中 `$method` 为空字符串。