### PR TITLE
为initializeLogger日志初始话函数添加判断分支

### DIFF
--- a/src/Foundation/Application.php
+++ b/src/Foundation/Application.php
@@ -33,6 +33,7 @@ use EasyWeChat\Support\Log;
 use Monolog\Handler\NullHandler;
 use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
+use Monolog\Handler\HandlerInterface;
 use Pimple\Container;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -229,6 +230,8 @@ class Application extends Container
 
         if (!$this['config']['debug'] || defined('PHPUNIT_RUNNING')) {
             $logger->pushHandler(new NullHandler());
+        } elseif ($this['config']['log.handler'] instanceof HandlerInterface) {
+            $logger->pushHandler($this['config']['log.handler']);
         } elseif ($logFile = $this['config']['log.file']) {
             $logger->pushHandler(new StreamHandler($logFile, $this['config']->get('log.level', Logger::WARNING)));
         }


### PR DESCRIPTION
#494 
为initializeLogger日志初始话函数添加判断分支，使其类似于cache初始函数能够从配置参数里面直接传递handler对象。便于使用统一的Monolog日志处理，而不是只能使用StreamHandler
在配置文件可以这样定义
```
$cache = new FilesystemCache('./cache');
$logFile = '/var/log/web/easywechat-'.date('Y-m-d').'.log';
$log = new StreamHandler($logFile, 'debug');

$optionArr = [
    'app_id' => '',
    'secret' => '',
    'token' => '',
    'debug'  => true,
    'cache' => $cache,
    'log' => [
        'handler' => $log,
        'level' => 'debug',
        'file'  => 'D:\MyJob\GitHub\wechat\tmp\easywechat.log', // XXX: 绝对路径！！！！
    ],
];
```