### PR TITLE
Changed method doc to the right accepted param type

### DIFF
--- a/src/Message/Raw.php
+++ b/src/Message/Raw.php
@@ -40,7 +40,7 @@ class Raw extends AbstractMessage
     /**
      * Constructor.
      *
-     * @param array $content
+     * @param string $content
      */
     public function __construct($content)
     {


### PR DESCRIPTION
Hi! Great work!

Apologies if this PR doesn't comply with your guidelines, I couldn't read them in their original language! Found a miss-matching method param type in the Raw class construct doc, hope this helps :)

Thanks!