### PR TITLE
for https://github.com/overtrue/wechat/issues/520

### DIFF
--- a/src/Payment/helpers.php
+++ b/src/Payment/helpers.php
@@ -45,12 +45,14 @@ function generate_sign(array $attributes, $key, $encryptMethod = 'md5')
  */
 function get_client_ip()
 {
-    // for php-cli(phpunit etc.)
-    if (empty($_SERVER['REMOTE_ADDR'])) {
-        return gethostbyname(gethostname());
+    if (!empty($_SERVER['REMOTE_ADDR'])) {
+        $ip = $_SERVER['REMOTE_ADDR'];
+    } else {
+        // for php-cli(phpunit etc.)
+        $ip = gethostbyname(gethostname());
     }
 
-    return $_SERVER['REMOTE_ADDR'];
+    return filter_var($ip, FILTER_VALIDATE_IP) ?: '127.0.0.1';
 }
 
 /**
@@ -60,10 +62,14 @@ function get_client_ip()
  */
 function get_server_ip()
 {
-    // for php-cli(phpunit etc.)
-    if (empty($_SERVER['SERVER_ADDR'])) {
-        return gethostbyname(gethostname());
+    if (!empty($_SERVER['SERVER_ADDR'])) {
+        $ip = $_SERVER['SERVER_ADDR'];
+    } elseif (!empty($_SERVER['SERVER_NAME'])) {
+        $ip = gethostbyname($_SERVER['SERVER_NAME']);
+    } else {
+        // for php-cli(phpunit etc.)
+        $ip = gethostbyname(gethostname());
     }
 
-    return $_SERVER['SERVER_ADDR'];
+    return filter_var($ip, FILTER_VALIDATE_IP) ?: '127.0.0.1';
 }


### PR DESCRIPTION
1. 当服务器机器名没有指向一个ip地址的时候 gethostbyname() 将会得到一个非 ip 的字符串（通常是该机器名）
2. $_SERVER['SERVER_ADDR'] 有时候不存在，使用 $_SERVER['SERVER_NAME'] 来尝试获取。
