### PR TITLE
改变了http 中 json 方法的接口, 从而支持 添加 添加 query参数

### DIFF
--- a/src/Core/Http.php
+++ b/src/Core/Http.php
@@ -110,17 +110,17 @@ class Http
      *
      * @param string       $url
      * @param string|array $options
+     * @param array $queries
      * @param int          $encodeOption
      *
      * @return ResponseInterface
      *
      * @throws HttpException
      */
-    public function json($url, $options = [], $encodeOption = JSON_UNESCAPED_UNICODE)
+     public function json($url, $options = [], $encodeOption = JSON_UNESCAPED_UNICODE, $queries = [])
     {
         is_array($options) && $options = json_encode($options, $encodeOption);
-
-        return $this->request($url, 'POST', ['body' => $options, 'headers' => ['content-type' => 'application/json']]);
+        return $this->request($url, 'POST', ['query' => $queries,'body' => $options, 'headers' => ['content-type' => 'application/json']]);
     }
 
     /**


### PR DESCRIPTION
本身 $queries 应该加在 $encodeOption = JSON_UNESCAPED_UNICODE的前面... 但是为了兼容性放在后面了... 
我发现post那个函数其实目前也是设计的不支持添加$queries的, 但是其实很多公众平台的参数都是有query的, 只是他正好也接受 post过去的值而已... 这边是不是应该调整的更符合文档一些?