### PR TITLE
fixed downloadBill method result

### DIFF
--- a/src/Payment/API.php
+++ b/src/Payment/API.php
@@ -298,7 +298,7 @@ class API extends AbstractAPI
             'bill_type' => $type,
         ];
 
-        return $this->request(self::API_DOWNLOAD_BILL, $params, 'post', [], true)->getBody();
+        return $this->request(self::API_DOWNLOAD_BILL, $params, 'post', [\GuzzleHttp\RequestOptions::STREAM => true], true)->getBody();
     }
 
     /**


### PR DESCRIPTION
Guzzle request options 建议是这样的:
[
    \GuzzleHttp\RequestOptions::STREAM => true
]
对账单返回的是一个\GuzzleHttp\Psr7\Stream对象,参数空导致Guzzle把响应当普通Response处理了,导致$stream->eof() === true
并且getContents方法是拿不到数据的,很容易对使用者造成迷惑