### PR TITLE
change request parameter

### DIFF
--- a/src/MiniProgram/QRCode/QRCode.php
+++ b/src/MiniProgram/QRCode/QRCode.php
@@ -45,6 +45,6 @@ class QRCode extends AbstractMiniProgram
      */
     public function create($path, $width = 430)
     {
-        return $this->parseJSON('POST', [self::API_CREATE_QRCODE, compact('path', 'width')]);
+        return $this->parseJSON('JSON', [self::API_CREATE_QRCODE, compact('path', 'width')]);
     }
 }


### PR DESCRIPTION
如果使用'POST'请求，微信服务器无法接收参数，而返回“param path length invalid”，改用'JSON'请求即可。