### PR TITLE
Allow client code configure its own GuzzleHTTP handler

### DIFF
--- a/src/Core/Http.php
+++ b/src/Core/Http.php
@@ -34,6 +34,12 @@ use Psr\Http\Message\ResponseInterface;
 class Http
 {
     /**
+     * Used to identify handler defined by client code
+     * Maybe useful in the future.
+     */
+    const USER_DEFINED_HANDLER = 'userDefined';
+
+    /**
      * Http client.
      *
      * @var HttpClient
@@ -297,6 +303,10 @@ class Http
 
         foreach ($this->middlewares as $middleware) {
             $stack->push($middleware);
+        }
+
+        if (isset(static::$defaults['handler']) && is_callable(static::$defaults['handler'])) {
+            $stack->push(static::$defaults['handler'], self::USER_DEFINED_HANDLER);
         }
 
         return $stack;

--- a/tests/Core/CoreHttpTest.php
+++ b/tests/Core/CoreHttpTest.php
@@ -209,8 +209,8 @@ namespace {
                     if (!isset($statistics[$api])) {
                         $statistics[$api] = 0;
                     }
-                    $statistics[$api]++;
-                })
+                    ++$statistics[$api];
+                }),
             ]);
 
             $httpClient = Mockery::mock(Client::class);
@@ -219,6 +219,7 @@ namespace {
                 if (isset($options['handler']) && ($options['handler'] instanceof HandlerStack)) {
                     $options['handler']($request, $options);
                 }
+
                 return true;
             })->andReturn(new Response());
 


### PR DESCRIPTION
这个PR希望允许客户端代码添加自定义GuzzleHTTP中间件。

一个现实情景是，希望获知不同HTTP API的使用情况，以免碰到次数限制。附带的测试就是用这个需求来模拟的。

虽然`EasyWeChat\Core\HTTP`实例可以通过`AbstractAPI::getHttp()`获得，但只适合访问个别组件的情况。鉴于handler本身也是`GuzzleHttp\Http`的options之一，所以想到利用相同的key为客户端提供设置默认设置的机会。当然`GuzzleHttp\Http`期望实际类型是`GuzzleHttp\HandlerStack`，客户端需要自行保证callable的正确性，好在可以用`GuzzleHttp\Middleware`提供的工厂方法。

写测试的时候头疼了一个小时，难写的测试往往提示实现不科学。感谢赐教！