### PR TITLE
Add payment scan notify handler

### DIFF
--- a/src/Payment/Payment.php
+++ b/src/Payment/Payment.php
@@ -121,7 +121,7 @@ class Payment
     /**
      * Handle native scan notify.
      * https://pay.weixin.qq.com/wiki/doc/api/native.php?chapter=6_4
-     * The callback shall return string of prepay_id or throw an exception
+     * The callback shall return string of prepay_id or throw an exception.
      *
      * @param callable $callback
      *

--- a/src/Payment/Payment.php
+++ b/src/Payment/Payment.php
@@ -119,6 +119,48 @@ class Payment
     }
 
     /**
+     * Handle native scan notify.
+     * https://pay.weixin.qq.com/wiki/doc/api/native.php?chapter=6_4
+     * The callback shall return string of prepay_id or throw an exception
+     *
+     * @param callable $callback
+     *
+     * @return Response
+     */
+    public function handleScanNotify(callable $callback)
+    {
+        $notify = $this->getNotify();
+
+        if (!$notify->isValid()) {
+            throw new FaultException('Invalid request payloads.', 400);
+        }
+
+        $notify = $notify->getNotify();
+
+        try {
+            $prepayId = call_user_func_array($callback, [$notify->get('product_id'), $notify->get('openid'), $notify]);
+            $response = [
+                'return_code' => 'SUCCESS',
+                'appid' => $this->merchant->app_id,
+                'mch_id' => $this->merchant->merchant_id,
+                'nonce_str' => uniqid(),
+                'prepay_id' => strval($prepayId),
+                'result_code' => 'SUCCESS',
+            ];
+            $response['sign'] = generate_sign($response, $this->merchant->key);
+        } catch (\Exception $e) {
+            $response = [
+                'return_code' => 'SUCCESS',
+                'return_msg' => $e->getCode(),
+                'result_code' => 'FAIL',
+                'err_code_des' => $e->getMessage(),
+            ];
+        }
+
+        return new Response(XML::build($response));
+    }
+
+    /**
      * [WeixinJSBridge] Generate js config for payment.
      *
      * <pre>

--- a/tests/Payment/PaymentPaymentTest.php
+++ b/tests/Payment/PaymentPaymentTest.php
@@ -117,6 +117,37 @@ class PaymentPaymentTest extends TestCase
     }
 
     /**
+     * Test handleNotify().
+     */
+    public function testHandleScanNotify()
+    {
+        $merchant = new Merchant(['key' => 'different_sign_key']);
+        $payment = Mockery::mock(Payment::class.'[getNotify]', [$merchant]);
+        $request = Request::create('/callback', 'POST', [], [], [], [], '<xml><product_id>88888</product_id><openid>o8GeHuLAsgefS_80exEr1cTqekUs</openid></xml>');
+        $notify = Mockery::mock(Notify::class.'[isValid]', [$merchant, $request]);
+        $notify->shouldReceive('isValid')->andReturn(true);
+        $payment->shouldReceive('getNotify')->andReturn($notify);
+
+        $response = $payment->handleScanNotify(function () {
+            return 'wx201410272009395522657a690389285100';
+        });
+
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertRegExp('#<prepay_id><!\[CDATA\[wx201410272009395522657a690389285100\]\]></prepay_id>#', $response->getContent());
+
+        $response = $payment->handleScanNotify(function () {
+            throw new \Exception('Operation failed', 1048);
+        });
+
+        $this->assertEquals(XML::build([
+            'return_code' => 'SUCCESS',
+            'return_msg' => 1048,
+            'result_code' => 'FAIL',
+            'err_code_des' => 'Operation failed',
+        ]), $response->getContent());
+    }
+
+    /**
      * test configForPayment.
      */
     public function testConfigForPayment()


### PR DESCRIPTION
微信支付扫码模式一：商户必须在公众平台后台设置支付回调URL。URL实现的功能：接收用户扫码后微信支付系统回调的productid和openid；调用微信支付统一下单API请求下单，获取交易会话标识（prepay_id），再将prepay_id返回给微信支付系统。
https://pay.weixin.qq.com/wiki/doc/api/native.php?chapter=6_4
现有的支付回调只能返回成功/失败，而这个流程要求在成功时返回签名的prepay_id。
这个PR增加了一个回调，方法签名为：
function(string $productId, string $openId, Collection $collection): string; (throws \Exception)
Collection为扩展保留，若成功返回，则构建响应XML。若抛出异常，则返回错误结果。
