### PR TITLE
生成 js添加到卡包接口 增加fixed_begintimestamp、outer_str字段

### DIFF
--- a/src/Card/Card.php
+++ b/src/Card/Card.php
@@ -211,6 +211,8 @@ class Card extends AbstractAPI
             'timestamp' => $timestamp,
             'outer_id' => Arr::get($extension, 'outer_id'),
             'balance' => Arr::get($extension, 'balance'),
+            'fixed_begintimestamp' => Arr::get($extension, 'fixed_begintimestamp'),
+            'outer_str' => Arr::get($extension, 'outer_str'),
         ];
         $ext['signature'] = $this->getSignature(
             $this->getAPITicket(),


### PR DESCRIPTION
fixed_begintimestamp：卡券在第三方系统的实际领取时间，为东八区时间戳（UTC+8,精确到秒）。当卡券的有效期类型为DATE_TYPE_FIX_TERM时专用，标识卡券的实际生效时间，用于解决商户系统内起始时间和领取时间不同步的问题。
outer_str：领取渠道参数，用于标识本次领取的渠道值。