### PR TITLE
开放平台大幅重构并且添加测试

### DIFF
--- a/src/Foundation/ServiceProviders/OpenPlatformServiceProvider.php
+++ b/src/Foundation/ServiceProviders/OpenPlatformServiceProvider.php
@@ -88,11 +88,15 @@ class OpenPlatformServiceProvider implements ServiceProviderInterface
             $server->setEncryptor($pimple['open_platform.encryptor']);
             $server->setContainer($pimple);
 
-            return new OpenPlatform(
+            $platform = new OpenPlatform(
                 $server,
                 $pimple['open_platform.access_token'],
                 $pimple['config']['open_platform']
             );
+
+            $platform->setContainer($pimple);
+
+            return $platform;
         };
 
         $pimple['open_platform.authorizer'] = function ($pimple) {

--- a/src/Foundation/ServiceProviders/OpenPlatformServiceProvider.php
+++ b/src/Foundation/ServiceProviders/OpenPlatformServiceProvider.php
@@ -54,23 +54,23 @@ class OpenPlatformServiceProvider implements ServiceProviderInterface
      */
     public function register(Container $pimple)
     {
-        $pimple['open_platform_verify_ticket'] = function ($pimple) {
+        $pimple['open_platform.verify_ticket'] = function ($pimple) {
             return new VerifyTicket(
                 $pimple['config']['open_platform']['app_id'],
                 $pimple['cache']
             );
         };
 
-        $pimple['open_platform_access_token'] = function ($pimple) {
+        $pimple['open_platform.access_token'] = function ($pimple) {
             return new AccessToken(
                 $pimple['config']['open_platform']['app_id'],
                 $pimple['config']['open_platform']['secret'],
-                $pimple['open_platform_verify_ticket'],
+                $pimple['open_platform.verify_ticket'],
                 $pimple['cache']
             );
         };
 
-        $pimple['open_platform_encryptor'] = function ($pimple) {
+        $pimple['open_platform.encryptor'] = function ($pimple) {
             return new Encryptor(
                 $pimple['config']['open_platform']['app_id'],
                 $pimple['config']['open_platform']['token'],
@@ -85,50 +85,50 @@ class OpenPlatformServiceProvider implements ServiceProviderInterface
 
             $server->debug($pimple['config']['debug']);
 
-            $server->setEncryptor($pimple['open_platform_encryptor']);
+            $server->setEncryptor($pimple['open_platform.encryptor']);
             $server->setContainer($pimple);
 
             return new OpenPlatform(
                 $server,
-                $pimple['open_platform_access_token'],
+                $pimple['open_platform.access_token'],
                 $pimple['config']['open_platform']
             );
         };
 
-        $pimple['open_platform_authorizer'] = function ($pimple) {
+        $pimple['open_platform.authorizer'] = function ($pimple) {
             return new Authorizer(
-                $pimple['open_platform_access_token'],
+                $pimple['open_platform.access_token'],
                 $pimple['config']['open_platform']
             );
         };
 
-        $pimple['open_platform_authorization'] = function($pimple) {
+        $pimple['open_platform.authorization'] = function($pimple) {
             return new Authorization(
-                $pimple['open_platform_authorizer'],
+                $pimple['open_platform.authorizer'],
                 $pimple['config']['open_platform']['app_id'],
                 $pimple['cache']
             );
         };
 
-        $pimple['open_platform_authorizer_token'] = function ($pimple) {
+        $pimple['open_platform.authorizer_token'] = function ($pimple) {
             return new AuthorizerToken(
                 $pimple['config']['open_platform']['app_id'],
-                $pimple['open_platform_authorization']
+                $pimple['open_platform.authorization']
             );
         };
 
         // Authorization events handlers.
-        $pimple['open_platform_handle_component_verify_ticket'] = function($pimple) {
-            return new ComponentVerifyTicket($pimple['open_platform_verify_ticket']);
+        $pimple['open_platform.handlers.component_verify_ticket'] = function($pimple) {
+            return new ComponentVerifyTicket($pimple['open_platform.verify_ticket']);
         };
-        $pimple['open_platform_handle_authorized'] = function($pimple) {
-            return new Authorized($pimple['open_platform_authorization']);
+        $pimple['open_platform.handlers.authorized'] = function($pimple) {
+            return new Authorized($pimple['open_platform.authorization']);
         };
-        $pimple['open_platform_handle_updateauthorized'] = function($pimple) {
-            return new UpdateAuthorized($pimple['open_platform_authorization']);
+        $pimple['open_platform.handlers.updateauthorized'] = function($pimple) {
+            return new UpdateAuthorized($pimple['open_platform.authorization']);
         };
-        $pimple['open_platform_handle_unauthorized'] = function($pimple) {
-            return new Unauthorized($pimple['open_platform_authorization']);
+        $pimple['open_platform.handlers.unauthorized'] = function($pimple) {
+            return new Unauthorized($pimple['open_platform.authorization']);
         };
     }
 

--- a/src/Foundation/ServiceProviders/OpenPlatformServiceProvider.php
+++ b/src/Foundation/ServiceProviders/OpenPlatformServiceProvider.php
@@ -12,27 +12,36 @@
 /**
  * OpenPlatformServiceProvider.php.
  *
- * This file is part of the wechat.
+ * Part of Overtrue\WeChat.
  *
- * (c) mingyoung <mingyoungcheung@gmail.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
  *
- * This source file is subject to the MIT license that is bundled
- * with this source code in the file LICENSE.
+ * @author    mingyoung <mingyoungcheung@gmail.com>
+ * @author    lixiao <leonlx126@gmail.com>
+ * @copyright 2016
+ *
+ * @see      https://github.com/overtrue
+ * @see      http://overtrue.me
  */
 
 namespace EasyWeChat\Foundation\ServiceProviders;
 
 use EasyWeChat\Encryption\Encryptor;
+use EasyWeChat\OpenPlatform\Authorization;
+use EasyWeChat\OpenPlatform\AuthorizerToken;
 use EasyWeChat\OpenPlatform\AccessToken;
+use EasyWeChat\OpenPlatform\Components\Authorizer;
+use EasyWeChat\OpenPlatform\EventHandlers\Authorized;
+use EasyWeChat\OpenPlatform\EventHandlers\UpdateAuthorized;
+use EasyWeChat\OpenPlatform\EventHandlers\Unauthorized;
+use EasyWeChat\OpenPlatform\EventHandlers\ComponentVerifyTicket;
 use EasyWeChat\OpenPlatform\Guard;
 use EasyWeChat\OpenPlatform\OpenPlatform;
 use EasyWeChat\OpenPlatform\VerifyTicket;
 use Pimple\Container;
 use Pimple\ServiceProviderInterface;
 
-/**
- * Class OpenPlatformServiceProvider.
- */
 class OpenPlatformServiceProvider implements ServiceProviderInterface
 {
     /**
@@ -45,9 +54,9 @@ class OpenPlatformServiceProvider implements ServiceProviderInterface
      */
     public function register(Container $pimple)
     {
-        $pimple['component_verify_ticket'] = function ($pimple) {
+        $pimple['open_platform_verify_ticket'] = function ($pimple) {
             return new VerifyTicket(
-                $pimple['config']['open_platform'],
+                $pimple['config']['open_platform']['app_id'],
                 $pimple['cache']
             );
         };
@@ -56,7 +65,7 @@ class OpenPlatformServiceProvider implements ServiceProviderInterface
             return new AccessToken(
                 $pimple['config']['open_platform']['app_id'],
                 $pimple['config']['open_platform']['secret'],
-                $pimple['component_verify_ticket'],
+                $pimple['open_platform_verify_ticket'],
                 $pimple['cache']
             );
         };
@@ -70,11 +79,14 @@ class OpenPlatformServiceProvider implements ServiceProviderInterface
         };
 
         $pimple['open_platform'] = function ($pimple) {
-            $server = new Guard($pimple['config']['open_platform']['token'], $pimple['component_verify_ticket']);
+            $server = new Guard(
+                $pimple['config']['open_platform']['token']
+            );
 
             $server->debug($pimple['config']['debug']);
 
             $server->setEncryptor($pimple['open_platform_encryptor']);
+            $server->setContainer($pimple);
 
             return new OpenPlatform(
                 $server,
@@ -82,5 +94,42 @@ class OpenPlatformServiceProvider implements ServiceProviderInterface
                 $pimple['config']['open_platform']
             );
         };
+
+        $pimple['open_platform_authorizer'] = function ($pimple) {
+            return new Authorizer(
+                $pimple['open_platform_access_token'],
+                $pimple['config']['open_platform']
+            );
+        };
+
+        $pimple['open_platform_authorization'] = function($pimple) {
+            return new Authorization(
+                $pimple['open_platform_authorizer'],
+                $pimple['config']['open_platform']['app_id'],
+                $pimple['cache']
+            );
+        };
+
+        $pimple['open_platform_authorizer_token'] = function ($pimple) {
+            return new AuthorizerToken(
+                $pimple['config']['open_platform']['app_id'],
+                $pimple['open_platform_authorization']
+            );
+        };
+
+        // Authorization events handlers.
+        $pimple['open_platform_handle_component_verify_ticket'] = function($pimple) {
+            return new ComponentVerifyTicket($pimple['open_platform_verify_ticket']);
+        };
+        $pimple['open_platform_handle_authorized'] = function($pimple) {
+            return new Authorized($pimple['open_platform_authorization']);
+        };
+        $pimple['open_platform_handle_updateauthorized'] = function($pimple) {
+            return new UpdateAuthorized($pimple['open_platform_authorization']);
+        };
+        $pimple['open_platform_handle_unauthorized'] = function($pimple) {
+            return new Unauthorized($pimple['open_platform_authorization']);
+        };
     }
+
 }

--- a/src/OpenPlatform/AccessToken.php
+++ b/src/OpenPlatform/AccessToken.php
@@ -53,7 +53,7 @@ class AccessToken extends WechatAccessToken
     /**
      * {@inheritdoc}.
      */
-    protected $prefix = 'easywechat.common.component_access_token.';
+    protected $prefix = 'easywechat.open_platform.component_access_token.';
 
     /**
      * AccessToken constructor.

--- a/src/OpenPlatform/Authorization.php
+++ b/src/OpenPlatform/Authorization.php
@@ -158,7 +158,7 @@ class Authorization
     public function handleAuthorizerAccessToken()
     {
         $data = $this->authorizer->getAuthorizationToken(
-            $this->appId,
+            $this->getAuthorizerAppId(),
             $this->getAuthorizerRefreshToken()
         );
 

--- a/src/OpenPlatform/Authorization.php
+++ b/src/OpenPlatform/Authorization.php
@@ -24,7 +24,6 @@ use EasyWeChat\Support\Collection;
 
 class Authorization
 {
-
     use Caches;
 
     const CACHE_KEY_ACCESS_TOKEN  = 'easywechat.open_platform.authorizer_access_token';
@@ -98,7 +97,8 @@ class Authorization
      *
      * @param $code
      */
-    public function setAuthCode($code) {
+    public function setAuthCode($code)
+    {
         $this->authCode = $code;
     }
 
@@ -107,7 +107,8 @@ class Authorization
      *
      * @return string
      */
-    public function getAuthCode() {
+    public function getAuthCode()
+    {
         return $this->authCode;
     }
 
@@ -116,7 +117,8 @@ class Authorization
      *
      * @param Collection $message
      */
-    public function setFromAuthMessage(Collection $message) {
+    public function setFromAuthMessage(Collection $message)
+    {
         if ($message->has('AuthorizerAppid')) {
             $this->setAuthorizerAppId($message->get('AuthorizerAppid'));
         }
@@ -253,14 +255,16 @@ class Authorization
     /**
      * Removes the authorizer access token from cache.
      */
-    public function removeAuthorizerAccessToken() {
+    public function removeAuthorizerAccessToken()
+    {
         $this->remove($this->getAuthorizerAccessTokenKey());
     }
 
     /**
      * Removes the authorizer refresh token from cache.
      */
-    public function removeAuthorizerRefreshToken() {
+    public function removeAuthorizerRefreshToken()
+    {
         $this->remove($this->getAuthorizerRefreshTokenKey());
     }
 

--- a/src/OpenPlatform/Authorization.php
+++ b/src/OpenPlatform/Authorization.php
@@ -1,0 +1,291 @@
+<?php
+/**
+ * Authorization.php.
+ *
+ * Part of Overtrue\WeChat.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author    lixiao <leonlx126@gmail.com>
+ * @copyright 2016
+ *
+ * @see      https://github.com/overtrue
+ * @see      http://overtrue.me
+ */
+
+namespace EasyWeChat\OpenPlatform;
+
+use Doctrine\Common\Cache\Cache;
+use EasyWeChat\Core\Exception;
+use EasyWeChat\OpenPlatform\Components\Authorizer;
+use EasyWeChat\OpenPlatform\Traits\Caches;
+use EasyWeChat\Support\Collection;
+
+class Authorization
+{
+
+    use Caches;
+
+    const CACHE_KEY_ACCESS_TOKEN  = 'easywechat.open_platform.authorizer_access_token';
+    const CACHE_KEY_REFRESH_TOKEN = 'easywechat.open_platform.authorizer_refresh_token';
+
+    /**
+     * Authorizer API.
+     *
+     * @var Authorizer
+     */
+    private $authorizer;
+
+    /**
+     * Open Platform App Id, aka, Component App Id.
+     *
+     * @var string
+     */
+    private $appId;
+
+    /**
+     * Authorizer App Id.
+     *
+     * @var string
+     */
+    private $authorizerAppId;
+
+    /**
+     * Auth code.
+     *
+     * @var string
+     */
+    private $authCode;
+
+    public function __construct(Authorizer $authorizer, $appId,
+                                Cache $cache = null)
+    {
+        $this->authorizer = $authorizer;
+        $this->appId = $appId;
+        $this->setCache($cache);
+    }
+
+    /**
+     * Sets the authorizer app id.
+     *
+     * @param string $authorizerAppId
+     */
+    public function setAuthorizerAppId($authorizerAppId)
+    {
+        $this->authorizerAppId = $authorizerAppId;
+    }
+
+    /**
+     * Gets the authorizer app id, or throws if not found.
+     *
+     * @return string
+     * @throws Exception
+     */
+    public function getAuthorizerAppId()
+    {
+        if (! $this->authorizerAppId) {
+            throw new Exception(
+                'Authorizer App Id is not present, you may not make the authorization yet.'
+            );
+        }
+
+        return $this->authorizerAppId;
+    }
+
+    /**
+     * Sets the auth code.
+     *
+     * @param $code
+     */
+    public function setAuthCode($code) {
+        $this->authCode = $code;
+    }
+
+    /**
+     * Gets the auth code.
+     *
+     * @return string
+     */
+    public function getAuthCode() {
+        return $this->authCode;
+    }
+
+    /**
+     * Sets the auth info from the message of the auth event sent by WeChat.
+     *
+     * @param Collection $message
+     */
+    public function setFromAuthMessage(Collection $message) {
+        if ($message->has('AuthorizerAppid')) {
+            $this->setAuthorizerAppId($message->get('AuthorizerAppid'));
+        }
+        if ($message->has('AuthorizationCode')) {
+            $this->setAuthCode($message->get('AuthorizationCode'));
+        }
+    }
+
+    /**
+     * Handles authorization: calls the API, saves the tokens.
+     *
+     * @return Collection
+     */
+    public function handleAuthorization()
+    {
+        $info = $this->getAuthorizationInfo();
+
+        $appId = $info['authorization_info']['authorizer_appid'];
+        $this->setAuthorizerAppId($appId);
+
+        $this->saveAuthorizerAccessToken($info['authorization_info']);
+        $this->saveAuthorizerRefreshToken($info['authorization_info']);
+
+        $authorizerInfo = $this->getAuthorizerInfo();
+        // Duplicated info.
+        $authorizerInfo->forget('authorization_info');
+        $info->merge($authorizerInfo->all());
+
+        return $info;
+    }
+
+    /**
+     * Handles the authorizer access token: calls the API, saves the token.
+     *
+     * @return string The authorizer access token.
+     */
+    public function handleAuthorizerAccessToken()
+    {
+        $data = $this->authorizer->getAuthorizationToken(
+            $this->appId,
+            $this->getAuthorizerRefreshToken()
+        );
+
+        $this->saveAuthorizerAccessToken($data);
+
+        return $data['authorizer_access_token'];
+    }
+
+    /**
+     * Gets the authorization information.
+     * Like authorizer app id, access token, refresh token, function scope, etc.
+     *
+     * @return Collection
+     */
+    public function getAuthorizationInfo()
+    {
+        $result = $this->authorizer->getAuthorizationInfo($this->getAuthCode());
+        if (is_array($result)) {
+            $result = new Collection($result);
+        }
+
+        return $result;
+    }
+
+    /**
+     * Gets the authorizer information.
+     * Like authorizer name, logo, business, etc.
+     *
+     * @return Collection
+     */
+    public function getAuthorizerInfo()
+    {
+        $result = $this->authorizer->getAuthorizerInfo($this->getAuthorizerAppId());
+        if (is_array($result)) {
+            $result = new Collection($result);
+        }
+
+        return $result;
+    }
+
+    /**
+     * Saves the authorizer access token in cache.
+     *
+     * @param Collection|array $data Array structure from WeChat API result.
+     */
+    public function saveAuthorizerAccessToken($data)
+    {
+        $accessToken = $data['authorizer_access_token'];
+        // Expiration time, -100 to avoid any delay.
+        $expire = $data['expires_in'] - 100;
+
+        $this->set($this->getAuthorizerAccessTokenKey(), $accessToken, $expire);
+    }
+
+    /**
+     * Gets the authorizer access token.
+     *
+     * @return string
+     */
+    public function getAuthorizerAccessToken()
+    {
+        return $this->get($this->getAuthorizerAccessTokenKey());
+    }
+
+    /**
+     * Saves the authorizer refresh token in cache.
+     *
+     * @param Collection|array $data Array structure from WeChat API result.
+     */
+    public function saveAuthorizerRefreshToken($data)
+    {
+        $refreshToken = $data['authorizer_refresh_token'];
+
+        $this->set($this->getAuthorizerRefreshTokenKey(), $refreshToken);
+    }
+
+    /**
+     * Gets the authorizer refresh token.
+     *
+     * @return string
+     * @throws Exception When refresh token is not present.
+     */
+    public function getAuthorizerRefreshToken()
+    {
+        if ($token = $this->get($this->getAuthorizerRefreshTokenKey())) {
+            return $token;
+        }
+
+        throw new Exception(
+            'Authorizer Refresh Token is not present, you may not make the authorization yet.'
+        );
+    }
+
+    /**
+     * Removes the authorizer access token from cache.
+     */
+    public function removeAuthorizerAccessToken() {
+        $this->remove($this->getAuthorizerAccessTokenKey());
+    }
+
+    /**
+     * Removes the authorizer refresh token from cache.
+     */
+    public function removeAuthorizerRefreshToken() {
+        $this->remove($this->getAuthorizerRefreshTokenKey());
+    }
+
+    /**
+     * Gets the authorizer access token cache key.
+     *
+     * @return string
+     */
+    public function getAuthorizerAccessTokenKey()
+    {
+        return self::CACHE_KEY_ACCESS_TOKEN
+            . '.' . $this->appId
+            . '.' . $this->getAuthorizerAppId();
+    }
+
+    /**
+     * Gets the authorizer refresh token cache key.
+     *
+     * @return string
+     */
+    public function getAuthorizerRefreshTokenKey()
+    {
+        return self::CACHE_KEY_REFRESH_TOKEN
+            . '.' . $this->appId
+            . '.' . $this->getAuthorizerAppId();
+    }
+
+}

--- a/src/OpenPlatform/AuthorizerToken.php
+++ b/src/OpenPlatform/AuthorizerToken.php
@@ -1,0 +1,82 @@
+<?php
+
+/*
+ * This file is part of the overtrue/wechat.
+ *
+ * (c) overtrue <i@overtrue.me>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+/**
+ * AuthorizerToken.php.
+ *
+ * Part of Overtrue\WeChat.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author    lixiao <leonlx126@gmail.com>
+ * @copyright 2016
+ *
+ * @see      https://github.com/overtrue
+ * @see      http://overtrue.me
+ */
+
+namespace EasyWeChat\OpenPlatform;
+
+use EasyWeChat\Core\AccessToken;
+
+/**
+ * Class AuthorizerToken
+ *
+ * AuthorizerToken is responsible for the access token of the authorizer,
+ * the complexity is that this access token also requires the refresh token
+ * of the authorizer which is acquired by the open platform authorization
+ * process.
+ *
+ * This completely overrides the original AccessToken.
+ *
+ * @package EasyWeChat\OpenPlatform
+ */
+class AuthorizerToken extends AccessToken {
+
+    /**
+     * Handles authorization.
+     *
+     * @var Authorization
+     */
+    protected $authorization;
+
+    /**
+     * AuthorizerAccessToken constructor.
+     *
+     * @param string $appId
+     * @param Authorization $authorization
+     */
+    public function __construct($appId, Authorization $authorization)
+    {
+        parent::__construct($appId, null);
+
+        $this->authorization = $authorization;
+    }
+
+    /**
+     * Get token from WeChat API.
+     *
+     * @param bool $forceRefresh
+     *
+     * @return string
+     */
+    public function getToken($forceRefresh = false)
+    {
+        $cached = $this->authorization->getAuthorizerAccessToken();
+
+        if ($forceRefresh || empty($cached)) {
+            return $this->authorization->handleAuthorizerAccessToken();
+        }
+
+        return $cached;
+    }
+}

--- a/src/OpenPlatform/AuthorizerToken.php
+++ b/src/OpenPlatform/AuthorizerToken.php
@@ -26,7 +26,10 @@
 
 namespace EasyWeChat\OpenPlatform;
 
-use EasyWeChat\Core\AccessToken;
+// Don't change the alias name please. I met the issue "name already in use"
+// when used in Laravel project, not sure what is causing it, this is quick
+// solution.
+use EasyWeChat\Core\AccessToken as BaseAccessToken;
 
 /**
  * Class AuthorizerToken
@@ -40,7 +43,7 @@ use EasyWeChat\Core\AccessToken;
  *
  * @package EasyWeChat\OpenPlatform
  */
-class AuthorizerToken extends AccessToken
+class AuthorizerToken extends BaseAccessToken
 {
     /**
      * Handles authorization.

--- a/src/OpenPlatform/AuthorizerToken.php
+++ b/src/OpenPlatform/AuthorizerToken.php
@@ -40,8 +40,8 @@ use EasyWeChat\Core\AccessToken;
  *
  * @package EasyWeChat\OpenPlatform
  */
-class AuthorizerToken extends AccessToken {
-
+class AuthorizerToken extends AccessToken
+{
     /**
      * Handles authorization.
      *

--- a/src/OpenPlatform/Components/AbstractComponent.php
+++ b/src/OpenPlatform/Components/AbstractComponent.php
@@ -34,7 +34,6 @@ use Symfony\Component\HttpFoundation\Request;
 
 abstract class AbstractComponent extends AbstractAPI
 {
-
     /**
      * Config.
      *

--- a/src/OpenPlatform/Components/AbstractComponent.php
+++ b/src/OpenPlatform/Components/AbstractComponent.php
@@ -18,6 +18,7 @@
  * file that was distributed with this source code.
  *
  * @author    mingyoung <mingyoungcheung@gmail.com>
+ * @author    lixiao <leonlx126@gmail.com>
  * @copyright 2016
  *
  * @see      https://github.com/overtrue
@@ -27,10 +28,13 @@
 namespace EasyWeChat\OpenPlatform\Components;
 
 use EasyWeChat\Core\AbstractAPI;
+use EasyWeChat\Core\AccessToken;
+use EasyWeChat\Core\Exception;
 use Symfony\Component\HttpFoundation\Request;
 
 abstract class AbstractComponent extends AbstractAPI
 {
+
     /**
      * Config.
      *
@@ -39,17 +43,24 @@ abstract class AbstractComponent extends AbstractAPI
     protected $config;
 
     /**
+     * AppId, component app id.
+     *
+     * @var string
+     */
+    private $appId;
+
+    /**
      * Request.
      *
-     * @var Symfony\Component\HttpFoundation\Request
+     * @var Request
      */
     protected $request;
 
     /**
      * AbstractComponent constructor.
      *
-     * @param \EasyWeChat\Core\AccessToken $accessToken
-     * @param array                        $config
+     * @param AccessToken $accessToken
+     * @param array $config
      * @param $request
      */
     public function __construct($accessToken, array $config, $request = null)
@@ -58,4 +69,44 @@ abstract class AbstractComponent extends AbstractAPI
         $this->config = $config;
         $this->request = $request ?: Request::createFromGlobals();
     }
+
+    /**
+     * Get AppId.
+     *
+     * @return string
+     * @throws Exception When app id is not present.
+     */
+    public function getAppId()
+    {
+        if ($this->appId) {
+            return $this->appId;
+        }
+
+        if (isset($this->config['open_platform'])) {
+            $this->appId = $this->config['open_platform']['app_id'];
+        } else {
+            $this->appId = $this->config['app_id'];
+        }
+
+        if (empty($this->appId)) {
+            throw new Exception('App Id is not present.');
+        }
+
+        return $this->appId;
+    }
+
+    /**
+     * Set AppId.
+     *
+     * @param string $appId
+     *
+     * @return $this
+     */
+    public function setAppId($appId)
+    {
+        $this->appId = $appId;
+
+        return $this;
+    }
+
 }

--- a/src/OpenPlatform/Components/Authorizer.php
+++ b/src/OpenPlatform/Components/Authorizer.php
@@ -18,6 +18,7 @@
  * file that was distributed with this source code.
  *
  * @author    mingyoung <mingyoungcheung@gmail.com>
+ * @author    lixiao <leonlx126@gmail.com>
  * @copyright 2016
  *
  * @see      https://github.com/overtrue
@@ -36,7 +37,7 @@ class Authorizer extends AbstractComponent
     /**
      * Authorization token api.
      */
-    const AUTHORIZATION_TOKEN = 'https://api.weixin.qq.com/cgi-bin/component/api_authorizer_token';
+    const GET_AUTHORIZER_TOKEN = 'https://api.weixin.qq.com/cgi-bin/component/api_authorizer_token';
 
     /**
      * Get authorizer info api.
@@ -54,17 +55,17 @@ class Authorizer extends AbstractComponent
     const SET_AUTHORIZER_OPTION = 'https://api.weixin.qq.com/cgi-bin/component/api_set_authorizer_option';
 
     /**
-     * Get authorizer info.
+     * Get authorization info.
      *
-     * @param $authorizationCode
+     * @param $authCode
      *
      * @return \EasyWeChat\Support\Collection
      */
-    public function getAuthInfo($authorizationCode = null)
+    public function getAuthorizationInfo($authCode = null)
     {
         $data = [
-            'component_appid' => $this->getComponentAppId(),
-            'authorization_code' => $authorizationCode ?: $this->request->get('auth_code'),
+            'component_appid' => $this->getAppId(),
+            'authorization_code' => $authCode ?: $this->request->get('auth_code'),
         ];
 
         return $this->parseJSON('json', [self::GET_AUTH_INFO, $data]);
@@ -81,12 +82,12 @@ class Authorizer extends AbstractComponent
     public function getAuthorizationToken($appId, $refreshToken)
     {
         $data = [
-            'component_appid' => $this->getComponentAppId(),
+            'component_appid' => $this->getAppId(),
             'authorizer_appid' => $appId,
             'authorizer_refresh_token' => $refreshToken,
         ];
 
-        return $this->parseJSON('json', [self::AUTHORIZATION_TOKEN, $data]);
+        return $this->parseJSON('json', [self::GET_AUTHORIZER_TOKEN, $data]);
     }
 
     /**
@@ -99,7 +100,7 @@ class Authorizer extends AbstractComponent
     public function getAuthorizerInfo($authorizerAppId)
     {
         $data = [
-            'component_appid' => $this->getComponentAppId(),
+            'component_appid' => $this->getAppId(),
             'authorizer_appid' => $authorizerAppId,
         ];
 
@@ -117,7 +118,7 @@ class Authorizer extends AbstractComponent
     public function getAuthorizerOption($authorizerAppId, $optionName)
     {
         $data = [
-            'component_appid' => $this->getComponentAppId(),
+            'component_appid' => $this->getAppId(),
             'authorizer_appid' => $authorizerAppId,
             'option_name' => $optionName,
         ];
@@ -137,7 +138,7 @@ class Authorizer extends AbstractComponent
     public function setAuthorizerOption($authorizerAppId, $optionName, $optionValue)
     {
         $data = [
-            'component_appid' => $this->getComponentAppId(),
+            'component_appid' => $this->getAppId(),
             'authorizer_appid' => $authorizerAppId,
             'option_name' => $optionName,
             'option_value' => $optionValue,
@@ -146,13 +147,4 @@ class Authorizer extends AbstractComponent
         return $this->parseJSON('json', [self::SET_AUTHORIZER_OPTION, $data]);
     }
 
-    /**
-     * Get component appId.
-     *
-     * @return string
-     */
-    private function getComponentAppId()
-    {
-        return $this->config['app_id'];
-    }
 }

--- a/src/OpenPlatform/Components/Authorizer.php
+++ b/src/OpenPlatform/Components/Authorizer.php
@@ -74,17 +74,17 @@ class Authorizer extends AbstractComponent
     /**
      * Get authorization token.
      *
-     * @param $appId
-     * @param $refreshToken
+     * @param $authorizerAppId
+     * @param $authorizerRefreshToken
      *
      * @return \EasyWeChat\Support\Collection
      */
-    public function getAuthorizationToken($appId, $refreshToken)
+    public function getAuthorizationToken($authorizerAppId, $authorizerRefreshToken)
     {
         $data = [
             'component_appid' => $this->getAppId(),
-            'authorizer_appid' => $appId,
-            'authorizer_refresh_token' => $refreshToken,
+            'authorizer_appid' => $authorizerAppId,
+            'authorizer_refresh_token' => $authorizerRefreshToken,
         ];
 
         return $this->parseJSON('json', [self::GET_AUTHORIZER_TOKEN, $data]);

--- a/src/OpenPlatform/Components/PreAuthCode.php
+++ b/src/OpenPlatform/Components/PreAuthCode.php
@@ -18,6 +18,7 @@
  * file that was distributed with this source code.
  *
  * @author    mingyoung <mingyoungcheung@gmail.com>
+ * @author    lixiao <leonlx126@gmail.com>
  * @copyright 2016
  *
  * @see      https://github.com/overtrue
@@ -43,46 +44,12 @@ class PreAuthCode extends AbstractComponent
     const PRE_AUTH_LINK = 'https://mp.weixin.qq.com/cgi-bin/componentloginpage?component_appid=%s&pre_auth_code=%s&redirect_uri=%s';
 
     /**
-     * AppId.
-     *
-     * @var string
-     */
-    private $appId;
-
-    /**
      * Redirect Uri.
      *
      * @var string
      */
     protected $redirectUri;
 
-    /**
-     * Get AppId.
-     *
-     * @return string
-     */
-    public function getAppId()
-    {
-        if (is_null($this->appId)) {
-            $this->appId = $this->config['app_id'];
-        }
-
-        return $this->appId;
-    }
-
-    /**
-     * Set AppId.
-     *
-     * @param string $appId
-     *
-     * @return $this
-     */
-    public function setAppId($appId)
-    {
-        $this->appId = $appId;
-
-        return $this;
-    }
 
     /**
      * Get pre auth code.
@@ -144,7 +111,7 @@ class PreAuthCode extends AbstractComponent
     public function getAuthLink()
     {
         return sprintf(self::PRE_AUTH_LINK,
-            $this->config['app_id'],
+            $this->getAppId(),
             $this->getCode(),
             Url::encode($this->getRedirectUri())
         );

--- a/src/OpenPlatform/EventHandlers/Authorized.php
+++ b/src/OpenPlatform/EventHandlers/Authorized.php
@@ -18,6 +18,7 @@
  * file that was distributed with this source code.
  *
  * @author    mingyoung <mingyoungcheung@gmail.com>
+ * @author    lixiao <leonlx126@gmail.com>
  * @copyright 2016
  *
  * @see      https://github.com/overtrue
@@ -26,15 +27,27 @@
 
 namespace EasyWeChat\OpenPlatform\EventHandlers;
 
+use EasyWeChat\OpenPlatform\Authorization;
 use EasyWeChat\Support\Collection;
 
-class Authorized extends EventHandler
-{
+class Authorized implements EventHandler {
+
+    /**
+     * @var Authorization
+     */
+    protected $authorization;
+
+    public function __construct(Authorization $authorization)
+    {
+        $this->authorization = $authorization;
+    }
+
     /**
      * {@inheritdoc}.
      */
     public function handle(Collection $message)
     {
-        //
+        $this->authorization->setFromAuthMessage($message);
+        $this->authorization->handleAuthorization();
     }
 }

--- a/src/OpenPlatform/EventHandlers/Authorized.php
+++ b/src/OpenPlatform/EventHandlers/Authorized.php
@@ -30,8 +30,8 @@ namespace EasyWeChat\OpenPlatform\EventHandlers;
 use EasyWeChat\OpenPlatform\Authorization;
 use EasyWeChat\Support\Collection;
 
-class Authorized implements EventHandler {
-
+class Authorized implements EventHandler
+{
     /**
      * @var Authorization
      */

--- a/src/OpenPlatform/EventHandlers/Authorized.php
+++ b/src/OpenPlatform/EventHandlers/Authorized.php
@@ -48,6 +48,6 @@ class Authorized implements EventHandler
     public function handle(Collection $message)
     {
         $this->authorization->setFromAuthMessage($message);
-        $this->authorization->handleAuthorization();
+        return $this->authorization->handleAuthorization();
     }
 }

--- a/src/OpenPlatform/EventHandlers/ComponentVerifyTicket.php
+++ b/src/OpenPlatform/EventHandlers/ComponentVerifyTicket.php
@@ -47,6 +47,6 @@ class ComponentVerifyTicket implements EventHandler
     {
         $this->getVerifyTicket()->cache($message);
 
-        return 'success';
+        return $message;
     }
 }

--- a/src/OpenPlatform/EventHandlers/ComponentVerifyTicket.php
+++ b/src/OpenPlatform/EventHandlers/ComponentVerifyTicket.php
@@ -18,6 +18,7 @@
  * file that was distributed with this source code.
  *
  * @author    mingyoung <mingyoungcheung@gmail.com>
+ * @author    lixiao <leonlx126@gmail.com>
  * @copyright 2016
  *
  * @see      https://github.com/overtrue
@@ -26,16 +27,25 @@
 
 namespace EasyWeChat\OpenPlatform\EventHandlers;
 
+use EasyWeChat\OpenPlatform\Traits\VerifyTicketTrait;
+use EasyWeChat\OpenPlatform\VerifyTicket;
 use EasyWeChat\Support\Collection;
 
-class ComponentVerifyTicket extends EventHandler
-{
+class ComponentVerifyTicket implements EventHandler {
+
+    use VerifyTicketTrait;
+
+    public function __construct(VerifyTicket $verifyTicket)
+    {
+        $this->setVerifyTicket($verifyTicket);
+    }
+
     /**
      * {@inheritdoc}.
      */
     public function handle(Collection $message)
     {
-        $this->verifyTicket->cache($message);
+        $this->getVerifyTicket()->cache($message);
 
         return 'success';
     }

--- a/src/OpenPlatform/EventHandlers/ComponentVerifyTicket.php
+++ b/src/OpenPlatform/EventHandlers/ComponentVerifyTicket.php
@@ -31,8 +31,8 @@ use EasyWeChat\OpenPlatform\Traits\VerifyTicketTrait;
 use EasyWeChat\OpenPlatform\VerifyTicket;
 use EasyWeChat\Support\Collection;
 
-class ComponentVerifyTicket implements EventHandler {
-
+class ComponentVerifyTicket implements EventHandler
+{
     use VerifyTicketTrait;
 
     public function __construct(VerifyTicket $verifyTicket)

--- a/src/OpenPlatform/EventHandlers/EventHandler.php
+++ b/src/OpenPlatform/EventHandlers/EventHandler.php
@@ -18,6 +18,7 @@
  * file that was distributed with this source code.
  *
  * @author    mingyoung <mingyoungcheung@gmail.com>
+ * @author    lixiao <leonlx126@gmail.com>
  * @copyright 2016
  *
  * @see      https://github.com/overtrue
@@ -26,27 +27,9 @@
 
 namespace EasyWeChat\OpenPlatform\EventHandlers;
 
-use EasyWeChat\OpenPlatform\VerifyTicket;
 use EasyWeChat\Support\Collection;
 
-abstract class EventHandler
-{
-    /**
-     * Component verify ticket instance.
-     *
-     * @var \EasyWeChat\OpenPlatform\VerifyTicket
-     */
-    protected $verifyTicket;
-
-    /**
-     * EventHandler constructor.
-     *
-     * @param VerifyTicket $verifyTicket
-     */
-    public function __construct(VerifyTicket $verifyTicket)
-    {
-        $this->verifyTicket = $verifyTicket;
-    }
+interface EventHandler {
 
     /**
      * Handle event.
@@ -55,17 +38,6 @@ abstract class EventHandler
      *
      * @return mixed
      */
-    abstract public function handle(Collection $message);
+    public function handle(Collection $message);
 
-    /**
-     * Forward handle.
-     *
-     * @param Collection $message
-     *
-     * @return Collection
-     */
-    public function forward(Collection $message)
-    {
-        return $message;
-    }
 }

--- a/src/OpenPlatform/EventHandlers/EventHandler.php
+++ b/src/OpenPlatform/EventHandlers/EventHandler.php
@@ -29,8 +29,8 @@ namespace EasyWeChat\OpenPlatform\EventHandlers;
 
 use EasyWeChat\Support\Collection;
 
-interface EventHandler {
-
+interface EventHandler
+{
     /**
      * Handle event.
      *

--- a/src/OpenPlatform/EventHandlers/Unauthorized.php
+++ b/src/OpenPlatform/EventHandlers/Unauthorized.php
@@ -18,6 +18,7 @@
  * file that was distributed with this source code.
  *
  * @author    mingyoung <mingyoungcheung@gmail.com>
+ * @author    lixiao <leonlx126@gmail.com>
  * @copyright 2016
  *
  * @see      https://github.com/overtrue
@@ -28,13 +29,16 @@ namespace EasyWeChat\OpenPlatform\EventHandlers;
 
 use EasyWeChat\Support\Collection;
 
-class Unauthorized extends EventHandler
+class Unauthorized extends Authorized
 {
+
     /**
-     * {@inheritdoc}.
+     * @inheritdoc
      */
     public function handle(Collection $message)
     {
-        //
+        $this->authorization->setFromAuthMessage($message);
+        $this->authorization->removeAuthorizerAccessToken();
+        $this->authorization->removeAuthorizerRefreshToken();
     }
 }

--- a/src/OpenPlatform/EventHandlers/Unauthorized.php
+++ b/src/OpenPlatform/EventHandlers/Unauthorized.php
@@ -31,7 +31,6 @@ use EasyWeChat\Support\Collection;
 
 class Unauthorized extends Authorized
 {
-
     /**
      * @inheritdoc
      */

--- a/src/OpenPlatform/EventHandlers/Unauthorized.php
+++ b/src/OpenPlatform/EventHandlers/Unauthorized.php
@@ -39,5 +39,7 @@ class Unauthorized extends Authorized
         $this->authorization->setFromAuthMessage($message);
         $this->authorization->removeAuthorizerAccessToken();
         $this->authorization->removeAuthorizerRefreshToken();
+
+        return $message;
     }
 }

--- a/src/OpenPlatform/EventHandlers/UpdateAuthorized.php
+++ b/src/OpenPlatform/EventHandlers/UpdateAuthorized.php
@@ -18,6 +18,7 @@
  * file that was distributed with this source code.
  *
  * @author    mingyoung <mingyoungcheung@gmail.com>
+ * @author    lixiao <leonlx126@gmail.com>
  * @copyright 2016
  *
  * @see      https://github.com/overtrue
@@ -26,15 +27,8 @@
 
 namespace EasyWeChat\OpenPlatform\EventHandlers;
 
-use EasyWeChat\Support\Collection;
-
-class UpdateAuthorized extends EventHandler
+class UpdateAuthorized extends Authorized
 {
-    /**
-     * {@inheritdoc}.
-     */
-    public function handle(Collection $message)
-    {
-        //
-    }
+
+    // Is this necessary to handle differently from Authorized?
 }

--- a/src/OpenPlatform/EventHandlers/UpdateAuthorized.php
+++ b/src/OpenPlatform/EventHandlers/UpdateAuthorized.php
@@ -29,6 +29,5 @@ namespace EasyWeChat\OpenPlatform\EventHandlers;
 
 class UpdateAuthorized extends Authorized
 {
-
     // Is this necessary to handle differently from Authorized?
 }

--- a/src/OpenPlatform/Guard.php
+++ b/src/OpenPlatform/Guard.php
@@ -65,7 +65,7 @@ class Guard extends ServerGuard
      *
      * @param Container $container
      *
-     * @see getHandler()
+     * @see getDefaultHandler()
      */
     public function setContainer(Container $container)
     {
@@ -134,7 +134,7 @@ class Guard extends ServerGuard
         if (is_array($message)) {
             $message = new Collection($message);
         }
-        $handler = $this->getHandler($message->get('InfoType'));
+        $handler = $this->getDefaultHandler($message->get('InfoType'));
 
         $result = $handler->handle($message);
 
@@ -142,7 +142,7 @@ class Guard extends ServerGuard
         // keeping the original message.
         if (is_array($result) || $result instanceof Collection) {
             $message->merge($result);
-        } else {
+        } else if (!empty($result)) {
             $message->set('result', $result);
         }
 
@@ -154,14 +154,14 @@ class Guard extends ServerGuard
     }
 
     /**
-     * Gets the handler by the info type..
+     * Gets the default handler by the info type.
      *
      * @param $type
      *
      * @return EventHandlers\EventHandler
      * @throws InvalidArgumentException
      */
-    protected function getHandler($type)
+    protected function getDefaultHandler($type)
     {
         $handler = $this->container->offsetGet("open_platform_handle_{$type}");
 

--- a/src/OpenPlatform/Guard.php
+++ b/src/OpenPlatform/Guard.php
@@ -127,8 +127,13 @@ class Guard extends ServerGuard
 
         $result = $handler->handle($message);
 
+        // To be compatible with previous version: merges the auth result while
+        // keeping the original message.
+        $message->merge($result);
+        $message = new Collection($message);
+
         if ($customHandler = $this->getMessageHandler()) {
-            $customHandler($message, $result);
+            $customHandler($message);
         }
 
         return $result;

--- a/src/OpenPlatform/Guard.php
+++ b/src/OpenPlatform/Guard.php
@@ -164,8 +164,7 @@ class Guard extends ServerGuard
      */
     protected function getDefaultHandler($type)
     {
-        $handler = $this->container->offsetGet("open_platform_handle_{$type}");
-
+        $handler = $this->container->offsetGet("open_platform.handlers.{$type}");
         if (! $handler) {
             throw new InvalidArgumentException("EventHandler \"$type\" does not exists.");
         }

--- a/src/OpenPlatform/Guard.php
+++ b/src/OpenPlatform/Guard.php
@@ -83,6 +83,41 @@ class Guard extends ServerGuard
     }
 
     /**
+     * Return for laravel-wechat.
+     *
+     * @return array
+     */
+    public function listServe()
+    {
+        $message = $this->getMessage();
+        $this->handleMessage($message);
+
+        $message = new Collection($message);
+
+        return [
+            $message->get('InfoType'), $message,
+        ];
+    }
+
+    /**
+     * Listen for wechat push event.
+     *
+     * @param callable|null $callback
+     *
+     * @return mixed
+     *
+     * @throws InvalidArgumentException
+     */
+    public function listen($callback = null)
+    {
+        if ($callback) {
+            $this->setMessageHandler($callback);
+        }
+
+        return $this->serve();
+    }
+
+    /**
      * @inheritdoc
      */
     protected function handleMessage($message)
@@ -93,7 +128,7 @@ class Guard extends ServerGuard
         $result = $handler->handle($message);
 
         if ($customHandler = $this->getMessageHandler()) {
-            $customHandler($result, $message);
+            $customHandler($message, $result);
         }
 
         return $result;

--- a/src/OpenPlatform/Guard.php
+++ b/src/OpenPlatform/Guard.php
@@ -36,7 +36,6 @@ use Symfony\Component\HttpFoundation\Response;
 
 class Guard extends ServerGuard
 {
-
     const EVENT_AUTHORIZED              = 'authorized';
     const EVENT_UNAUTHORIZED            = 'unauthorized';
     const EVENT_UPDATE_AUTHORIZED       = 'updateauthorized';
@@ -142,8 +141,10 @@ class Guard extends ServerGuard
         // keeping the original message.
         if (is_array($result) || $result instanceof Collection) {
             $message->merge($result);
-        } else if (!empty($result)) {
-            $message->set('result', $result);
+        } else {
+            if (! empty($result)) {
+                $message->set('result', $result);
+            }
         }
 
         if ($customHandler = $this->getMessageHandler()) {

--- a/src/OpenPlatform/OpenPlatform.php
+++ b/src/OpenPlatform/OpenPlatform.php
@@ -28,6 +28,7 @@ namespace EasyWeChat\OpenPlatform;
 
 use EasyWeChat\Core\Exceptions\InvalidArgumentException;
 use EasyWeChat\Support\Arr;
+use Pimple\Container;
 
 /**
  * Class OpenPlatform.
@@ -35,6 +36,8 @@ use EasyWeChat\Support\Arr;
  * @property \EasyWeChat\OpenPlatform\Guard $server
  * @property \EasyWeChat\OpenPlatform\Components\PreAuthCode $pre_auth
  * @property \EasyWeChat\OpenPlatform\AccessToken $access_token
+ * @property \EasyWeChat\OpenPlatform\AuthorizerToken $authorizer_token;
+ * @property \EasyWeChat\OpenPlatform\Authorization $authorization;
  * @property \EasyWeChat\OpenPlatform\Components\Authorizer $authorizer
  */
 class OpenPlatform
@@ -61,6 +64,13 @@ class OpenPlatform
     protected $config;
 
     /**
+     * Container in the scope of the open platform.
+     *
+     * @var Container
+     */
+    protected $container;
+
+    /**
      * Components.
      *
      * @var array
@@ -85,6 +95,16 @@ class OpenPlatform
     }
 
     /**
+     * Sets the container for use of the platform.
+     *
+     * @param Container $container
+     */
+    public function setContainer(Container $container)
+    {
+        $this->container = $container;
+    }
+
+    /**
      * Magic get access.
      *
      * @param $name
@@ -101,6 +121,10 @@ class OpenPlatform
 
         if ($class = Arr::get($this->components, $name)) {
             return new $class($this->access_token, $this->config);
+        }
+
+        if ($instance = $this->container->offsetGet("open_platform.{$name}")) {
+            return $instance;
         }
 
         throw new InvalidArgumentException("Property or component \"$name\" does not exists.");

--- a/src/OpenPlatform/Traits/Caches.php
+++ b/src/OpenPlatform/Traits/Caches.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * Trait Caches.php.
+ *
+ * Part of Overtrue\WeChat.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author    lixiao <leonlx126@gmail.com>
+ * @copyright 2016
+ *
+ * @see      https://github.com/overtrue
+ * @see      http://overtrue.me
+ */
+
+namespace EasyWeChat\OpenPlatform\Traits;
+
+use Doctrine\Common\Cache\Cache;
+use Doctrine\Common\Cache\FilesystemCache;
+
+trait Caches {
+
+    /**
+     * @var Cache
+     */
+    protected $cache;
+
+    /**
+     * Sets cache store.
+     *
+     * @param Cache $cache
+     *
+     * @return $this
+     */
+    public function setCache(Cache $cache)
+    {
+        $this->cache = $cache;
+
+        return $this;
+    }
+
+    /**
+     * Gets cache store. Defaults to file system in system temp folder.
+     *
+     * @return Cache
+     */
+    public function getCache()
+    {
+        return $this->cache ?: $this->cache = new FilesystemCache(sys_get_temp_dir());
+    }
+
+    /**
+     * Gets the cached data.
+     *
+     * @param string $key
+     * @param mixed $default A default value or a callable to return the value.
+     *
+     * @return mixed
+     */
+    public function get($key, $default = null)
+    {
+        if ($cached = $this->getCache()->fetch($key)) {
+            return $cached;
+        }
+
+        if (is_callable($default)) {
+            return $default();
+        }
+
+        return $default;
+    }
+
+    /**
+     * Sets the cached data.
+     *
+     * @param string $key
+     * @param mixed $value
+     * @param int $life Cache life time in seconds.
+     *
+     * @return bool
+     */
+    public function set($key, $value, $life = 0)
+    {
+        return $this->getCache()->save($key, $value, $life);
+    }
+
+    /**
+     * Removes the cached data.
+     *
+     * @param string $key
+     *
+     * @return bool
+     */
+    public function remove($key) {
+        return $this->getCache()->delete($key);
+    }
+
+}

--- a/src/OpenPlatform/Traits/Caches.php
+++ b/src/OpenPlatform/Traits/Caches.php
@@ -19,8 +19,8 @@ namespace EasyWeChat\OpenPlatform\Traits;
 use Doctrine\Common\Cache\Cache;
 use Doctrine\Common\Cache\FilesystemCache;
 
-trait Caches {
-
+trait Caches
+{
     /**
      * @var Cache
      */
@@ -92,7 +92,8 @@ trait Caches {
      *
      * @return bool
      */
-    public function remove($key) {
+    public function remove($key)
+    {
         return $this->getCache()->delete($key);
     }
 

--- a/src/OpenPlatform/VerifyTicket.php
+++ b/src/OpenPlatform/VerifyTicket.php
@@ -32,8 +32,8 @@ use EasyWeChat\Core\Exceptions\RuntimeException;
 use EasyWeChat\OpenPlatform\Traits\Caches;
 use EasyWeChat\Support\Collection;
 
-class VerifyTicket {
-
+class VerifyTicket
+{
     use Caches;
 
     /**
@@ -70,7 +70,8 @@ class VerifyTicket {
      * @param string $appId
      * @param Cache $cache
      */
-    public function __construct($appId, Cache $cache = null) {
+    public function __construct($appId, Cache $cache = null)
+    {
         $this->appId = $appId;
         $this->setCache($cache);
     }
@@ -82,7 +83,8 @@ class VerifyTicket {
      *
      * @return bool
      */
-    public function cache(Collection $message) {
+    public function cache(Collection $message)
+    {
         return $this->set(
             $this->getCacheKey(),
             $message->get($this->ticketXmlName)
@@ -96,7 +98,8 @@ class VerifyTicket {
      *
      * @throws RuntimeException
      */
-    public function getTicket() {
+    public function getTicket()
+    {
         if ($cached = $this->get($this->getCacheKey())) {
             return $cached;
         }
@@ -111,7 +114,8 @@ class VerifyTicket {
      *
      * @return $this
      */
-    public function setCacheKey($cacheKey) {
+    public function setCacheKey($cacheKey)
+    {
         $this->cacheKey = $cacheKey;
 
         return $this;
@@ -122,7 +126,8 @@ class VerifyTicket {
      *
      * @return string $this->cacheKey
      */
-    public function getCacheKey() {
+    public function getCacheKey()
+    {
         if (is_null($this->cacheKey)) {
             return $this->prefix . $this->appId;
         }

--- a/src/OpenPlatform/VerifyTicket.php
+++ b/src/OpenPlatform/VerifyTicket.php
@@ -62,7 +62,7 @@ class VerifyTicket {
      *
      * @var string
      */
-    protected $prefix = 'easywechat.common.component_verify_ticket.';
+    protected $prefix = 'easywechat.open_platform.component_verify_ticket.';
 
     /**
      * VerifyTicket constructor.

--- a/src/OpenPlatform/VerifyTicket.php
+++ b/src/OpenPlatform/VerifyTicket.php
@@ -18,6 +18,7 @@
  * file that was distributed with this source code.
  *
  * @author    mingyoung <mingyoungcheung@gmail.com>
+ * @author    lixiao <leonlx126@gmail.com>
  * @copyright 2016
  *
  * @see      https://github.com/overtrue
@@ -27,25 +28,20 @@
 namespace EasyWeChat\OpenPlatform;
 
 use Doctrine\Common\Cache\Cache;
-use Doctrine\Common\Cache\FilesystemCache;
 use EasyWeChat\Core\Exceptions\RuntimeException;
+use EasyWeChat\OpenPlatform\Traits\Caches;
 use EasyWeChat\Support\Collection;
 
-class VerifyTicket
-{
-    /**
-     * Config.
-     *
-     * @var array
-     */
-    protected $config;
+class VerifyTicket {
+
+    use Caches;
 
     /**
-     * Cache.
+     * App Id.
      *
-     * @var Cache
+     * @var string
      */
-    private $cache;
+    protected $appId;
 
     /**
      * Cache Key.
@@ -71,13 +67,12 @@ class VerifyTicket
     /**
      * VerifyTicket constructor.
      *
-     * @param array                        $config
-     * @param \Doctrine\Common\Cache\Cache $cache
+     * @param string $appId
+     * @param Cache $cache
      */
-    public function __construct($config, Cache $cache = null)
-    {
-        $this->config = $config;
-        $this->cache = $cache;
+    public function __construct($appId, Cache $cache = null) {
+        $this->appId = $appId;
+        $this->setCache($cache);
     }
 
     /**
@@ -87,9 +82,8 @@ class VerifyTicket
      *
      * @return bool
      */
-    public function cache(Collection $message)
-    {
-        return $this->getCache()->save(
+    public function cache(Collection $message) {
+        return $this->set(
             $this->getCacheKey(),
             $message->get($this->ticketXmlName)
         );
@@ -102,39 +96,12 @@ class VerifyTicket
      *
      * @throws RuntimeException
      */
-    public function getTicket()
-    {
-        $cached = $this->getCache()->fetch($this->getCacheKey());
-
-        if (empty($cached)) {
-            throw new RuntimeException('Component verify ticket does not exists.');
+    public function getTicket() {
+        if ($cached = $this->get($this->getCacheKey())) {
+            return $cached;
         }
 
-        return $cached;
-    }
-
-    /**
-     * Set cache.
-     *
-     * @param \Doctrine\Common\Cache\Cache $cache
-     *
-     * @return VerifyTicket
-     */
-    public function setCache(Cache $cache)
-    {
-        $this->cache = $cache;
-
-        return $this;
-    }
-
-    /**
-     * Return the cache manager.
-     *
-     * @return \Doctrine\Common\Cache\Cache
-     */
-    public function getCache()
-    {
-        return $this->cache ?: $this->cache = new FilesystemCache(sys_get_temp_dir());
+        throw new RuntimeException('Component verify ticket does not exists.');
     }
 
     /**
@@ -144,8 +111,7 @@ class VerifyTicket
      *
      * @return $this
      */
-    public function setCacheKey($cacheKey)
-    {
+    public function setCacheKey($cacheKey) {
         $this->cacheKey = $cacheKey;
 
         return $this;
@@ -156,10 +122,9 @@ class VerifyTicket
      *
      * @return string $this->cacheKey
      */
-    public function getCacheKey()
-    {
+    public function getCacheKey() {
         if (is_null($this->cacheKey)) {
-            return $this->prefix.$this->config['app_id'];
+            return $this->prefix . $this->appId;
         }
 
         return $this->cacheKey;

--- a/src/Server/Guard.php
+++ b/src/Server/Guard.php
@@ -391,7 +391,7 @@ class Guard
         if (!is_callable($handler)) {
             Log::debug('No handler enabled.');
 
-            return;
+            return null;
         }
 
         Log::debug('Message detail:', $message);

--- a/src/Support/Collection.php
+++ b/src/Support/Collection.php
@@ -101,7 +101,7 @@ class Collection implements ArrayAccess, Countable, IteratorAggregate, JsonSeria
     /**
      * Merge data.
      *
-     * @param array $items
+     * @param Collection|array $items
      *
      * @return array
      */

--- a/src/Support/Log.php
+++ b/src/Support/Log.php
@@ -29,6 +29,15 @@ use Psr\Log\LoggerInterface;
 
 /**
  * Class Log.
+ *
+ * @method static debug($message, $context = null)
+ * @method static info($message, $context = null)
+ * @method static notice($message, $context = null)
+ * @method static warning($message, $context = null)
+ * @method static error($message, $context = null)
+ * @method static critical($message, $context = null)
+ * @method static alert($message, $context = null)
+ * @method static emergency($message, $context = null)
  */
 class Log
 {

--- a/tests/OpenPlatform/AuthorizationHandlerTest.php
+++ b/tests/OpenPlatform/AuthorizationHandlerTest.php
@@ -1,0 +1,85 @@
+<?php
+
+/**
+ * Test AuthHandlerTest.php.
+ *
+ * @author lixiao <leonlx126@gmail.com>
+ */
+
+use EasyWeChat\OpenPlatform\EventHandlers\Authorized;
+use EasyWeChat\OpenPlatform\EventHandlers\Unauthorized;
+use EasyWeChat\Support\Collection;
+
+class AuthorizationHandlerTest extends AuthorizationTest
+{
+
+    public function testAuthorized()
+    {
+        $appId = 'appid@123';
+        $authorizerAppId = 'appid@456';
+        $authorizerAccessToken = 'access@123';
+        $authorizerRefreshToken = 'refresh@123';
+        $authorization = $this->make(
+            $appId, $authorizerAppId,
+            $authorizerAccessToken, $authorizerRefreshToken
+        );
+
+        $message = [
+            'AppId'                        => 'open-platform-app-id',
+            'CreateTIme'                   => '1413192760',
+            'InfoType'                     => 'authorized',
+            'AuthorizerAppid'              => 'authorizer-app-id',
+            'AuthorizationCode'            => 'auth-code',
+            'AuthorizationCodeExpiredTime' => '600',
+        ];
+        $authorized = new Authorized($authorization);
+        $authorized->handle(new Collection($message));
+
+        $this->assertEquals(
+            $authorizerAccessToken,
+            $authorization->getAuthorizerAccessToken()
+        );
+        $this->assertEquals(
+            $authorizerRefreshToken,
+            $authorization->getAuthorizerRefreshToken()
+        );
+    }
+
+    public function testUnauthorized()
+    {
+        $appId = 'appid@123';
+        $authorizerAppId = 'appid@456';
+        $authorizerAccessToken = 'access@123';
+        $authorizerRefreshToken = 'refresh@123';
+        $authorization = $this->make(
+            $appId, $authorizerAppId,
+            $authorizerAccessToken, $authorizerRefreshToken
+        );
+
+        // Authorized => saves the tokens.
+        $message = [
+            'AppId'                        => 'open-platform-app-id',
+            'CreateTIme'                   => '1413192760',
+            'InfoType'                     => 'authorized',
+            'AuthorizerAppid'              => 'authorizer-app-id',
+            'AuthorizationCode'            => 'auth-code',
+            'AuthorizationCodeExpiredTime' => '600',
+        ];
+        $authorized = new Authorized($authorization);
+        $authorized->handle(new Collection($message));
+
+        // Unauthorized => removes the tokens.
+        $message = [
+            'AppId'           => 'open-platform-app-id',
+            'CreateTIme'      => '1413192760',
+            'InfoType'        => 'authorized',
+            'AuthorizerAppid' => 'authorizer-app-id',
+        ];
+        $authorized = new Unauthorized($authorization);
+        $authorized->handle(new Collection($message));
+
+        $this->assertNull($authorization->getAuthorizerAccessToken());
+        $this->setExpectedException(\EasyWeChat\Core\Exception::class);
+        $this->assertNull($authorization->getAuthorizerRefreshToken());
+    }
+}

--- a/tests/OpenPlatform/AuthorizationTest.php
+++ b/tests/OpenPlatform/AuthorizationTest.php
@@ -1,0 +1,246 @@
+<?php
+
+/**
+ * Test AuthorizationTest.php.
+ *
+ * @author lixiao <leonlx126@gmail.com>
+ */
+
+use Doctrine\Common\Cache\ArrayCache;
+use EasyWeChat\OpenPlatform\Authorization;
+use EasyWeChat\OpenPlatform\Components\Authorizer;
+
+class AuthorizationTest extends TestCase
+{
+
+    public function testGetAuthorizationInfo()
+    {
+        $appId = 'appid@123';
+        $authorizerAppId = 'appid@456';
+        $authorization = $this->make($appId, $authorizerAppId);
+
+        $result = $authorization->getAuthorizationInfo();
+        $this->assertEquals($this->stubAuthorizationInfo($authorizerAppId), $result->all());
+    }
+
+    public function testGetAuthorizerInfo()
+    {
+        $appId = 'appid@123';
+        $authorizerAppId = 'appid@456';
+        $authorization = $this->make($appId, $authorizerAppId);
+
+        $result = $authorization->getAuthorizerInfo();
+        $this->assertEquals($this->stubAuthorizerInfo($authorizerAppId), $result->all());
+    }
+
+    public function testSaveAndGetAuthorizerAccessToken()
+    {
+        $appId = 'appid@123';
+        $authorizerAppId = 'appid@456';
+        $authorizerAccessToken = 'access@123';
+        $authorization = $this->make($appId, $authorizerAppId);
+
+        $stub = $this->stubAuthorizationInfo(
+            $authorizerAppId, $authorizerAccessToken);
+
+        $authorization->saveAuthorizerAccessToken($stub['authorization_info']);
+        $result = $authorization->getAuthorizerAccessToken();
+
+        $this->assertEquals($authorizerAccessToken, $result);
+    }
+
+    public function testSaveAndGetAuthorizerRefreshToken()
+    {
+        $appId = 'appid@123';
+        $authorizerAppId = 'appid@456';
+        $authorizerAccessToken = 'access@123';
+        $authorizerRefreshToken = 'refresh@123';
+        $authorization = $this->make($appId, $authorizerAppId);
+
+        $stub = $this->stubAuthorizationInfo($authorizerAppId,
+            $authorizerAccessToken, $authorizerRefreshToken);
+
+        $authorization->saveAuthorizerRefreshToken($stub['authorization_info']);
+        $result = $authorization->getAuthorizerRefreshToken();
+
+        $this->assertEquals($authorizerRefreshToken, $result);
+    }
+
+    public function testHandleAuthorizerAccessToken()
+    {
+        $appId = 'appid@123';
+        $authorizerAppId = 'appid@456';
+        $authorizerAccessToken = 'access@123';
+        $authorizerRefreshToken = 'refresh@123';
+        $authorization = $this->make(
+            $appId, $authorizerAppId,
+            $authorizerAccessToken, $authorizerRefreshToken
+        );
+
+        $stub = $this->stubAuthorizationInfo($authorizerAppId, $authorizerRefreshToken);
+        $authorization->saveAuthorizerRefreshToken($stub['authorization_info']);
+
+        $result = $authorization->handleAuthorizerAccessToken();
+        $this->assertEquals($authorizerAccessToken, $result);
+    }
+
+    public function testHandleAuthorization()
+    {
+        $appId = 'appid@123';
+        $authorizerAppId = 'appid@456';
+        $authorizerAccessToken = 'access@123';
+        $authorizerRefreshToken = 'refresh@123';
+        $authorization = $this->make(
+            $appId, $authorizerAppId,
+            $authorizerAccessToken, $authorizerRefreshToken
+        );
+
+        $stub = $this->stubAuthorizationAll($authorizerAppId,
+            $authorizerAccessToken, $authorizerRefreshToken);
+        $result = $authorization->handleAuthorization();
+        $this->assertEquals($stub, $result->all());
+
+        $savedAccessToken = $authorization->getAuthorizerAccessToken();
+        $savedRefreshToken = $authorization->getAuthorizerRefreshToken();
+
+        $this->assertEquals($authorizerAccessToken, $savedAccessToken);
+        $this->assertEquals($authorizerRefreshToken, $savedRefreshToken);
+    }
+
+    /**
+     * Authorization mock.
+     *
+     * @param string $appId
+     * @param string $authorizerAppId
+     * @param string $authorizerAccessToken
+     * @param string $authorizerRefreshToken
+     *
+     * @return Authorization
+     */
+    protected function make($appId, $authorizerAppId,
+                          $authorizerAccessToken = null,
+                          $authorizerRefreshToken = null)
+    {
+        /** @var Authorizer|\Mockery\MockInterface $mockAuthorizer */
+        $mockAuthorizer = Mockery::mock(Authorizer::class);
+
+        $mockAuthorizer
+            ->shouldReceive('getAuthorizationInfo')
+            ->andReturn(
+                $this->stubAuthorizationInfo(
+                    $authorizerAppId,
+                    $authorizerAccessToken,
+                    $authorizerRefreshToken
+                )
+            );
+
+        $mockAuthorizer
+            ->shouldReceive('getAuthorizerInfo')
+            ->andReturn($this->stubAuthorizerInfo($authorizerAppId));
+
+        $stub = $this->stubAuthorizerToken(
+            $authorizerAccessToken, $authorizerRefreshToken
+        );
+        /** @noinspection PhpUnusedParameterInspection */
+        $mockAuthorizer
+            ->shouldReceive('getAuthorizationToken')
+            ->andReturnUsing(
+                function ($appId, $authorizerRefreshToken)
+                use ($stub) {
+                    return $stub;
+                }
+            );
+
+        $cache = new ArrayCache();
+        $authorization = new Authorization($mockAuthorizer, $appId, $cache);
+        $authorization->setAuthorizerAppId($authorizerAppId);
+
+        return $authorization;
+    }
+
+    protected function stubAuthorizationInfo($authorizerAppId,
+                                           $authorizerAccessToken = null,
+                                           $authorizerRefreshToken = null)
+    {
+        $overrides = [
+            'authorization_info' => [
+                'authorizer_appid' => $authorizerAppId,
+            ],
+        ];
+        if ($authorizerAccessToken) {
+            $overrides['authorization_info']['authorizer_access_token']
+                = $authorizerAccessToken;
+        }
+        if ($authorizerRefreshToken) {
+            $overrides['authorization_info']['authorizer_refresh_token']
+                = $authorizerRefreshToken;
+        }
+
+        return $this->stub('authorization_info', $overrides);
+    }
+
+    protected function stubAuthorizerInfo($authorizerAppId)
+    {
+        $overrides = [
+            'authorization_info' => [
+                'appid' => $authorizerAppId,
+            ],
+        ];
+
+        return $this->stub('authorizer_info', $overrides);
+    }
+
+    protected function stubAuthorizationAll($authorizerAppId,
+                                          $authorizerAccessToken = null,
+                                          $authorizerRefreshToken = null)
+    {
+        $overrides = [
+            'authorization_info' => [
+                'authorizer_appid'         => $authorizerAppId,
+                'authorizer_access_token'  => $authorizerAccessToken,
+                'authorizer_refresh_token' => $authorizerRefreshToken,
+            ],
+        ];
+
+        return $this->stub('authorization_all', $overrides);
+    }
+
+    protected function stubAuthorizerToken($authorizerAccessToken,
+                                         $authorizerRefreshToken)
+    {
+        $overrides = [
+            'authorizer_access_token'  => $authorizerAccessToken,
+            'authorizer_refresh_token' => $authorizerRefreshToken,
+        ];
+
+        return $this->stub('authorizer_token', $overrides);
+    }
+
+    protected function stub($file, $overrides = null)
+    {
+        $json = file_get_contents("tests/OpenPlatform/stubs/{$file}.json");
+        $data = json_decode($json, true);
+
+        if ($overrides) {
+            $data = $this->overrides($data, $overrides);
+        }
+
+        return $data;
+    }
+
+    protected function overrides(array &$array1, array &$array2)
+    {
+        $merged = $array1;
+
+        foreach ($array2 as $key => &$value) {
+            if (is_array($value) && isset($merged [$key]) && is_array($merged [$key])) {
+                $merged [$key] = $this->overrides($merged [$key], $value);
+            } else {
+                $merged [$key] = $value;
+            }
+        }
+
+        return $merged;
+    }
+
+}

--- a/tests/OpenPlatform/AuthorizerTest.php
+++ b/tests/OpenPlatform/AuthorizerTest.php
@@ -1,0 +1,132 @@
+<?php
+
+/**
+ * Test AuthorizerTest.php.
+ *
+ * @author lixiao <leonlx126@gmail.com>
+ */
+
+use EasyWeChat\OpenPlatform\AccessToken;
+use EasyWeChat\OpenPlatform\Components\Authorizer;
+
+class AuthorizerTest extends TestCase {
+
+    /**
+     * Authorizer mock.
+     *
+     * @param $appId
+     *
+     * @return \Mockery\MockInterface|Authorizer
+     */
+    public function mockAuthorizer($appId)
+    {
+        $authorizer = Mockery::mock(
+            Authorizer::class . '[parseJSON]',
+            [
+                Mockery::mock(AccessToken::class),
+                ['open_platform' => ['app_id' => $appId]],
+            ]
+        );
+
+        /** @noinspection PhpUnusedParameterInspection */
+        $authorizer
+            ->shouldReceive('parseJSON')
+            ->andReturnUsing(function ($method, $params) {
+                return [
+                    'api'    => $params[0],
+                    'params' => empty($params[1]) ? null : $params[1],
+                ];
+            });
+
+        return $authorizer;
+    }
+
+    public function testGetAuthorizationInfo()
+    {
+        $appId = 'appid@123';
+        $authorizer = $this->mockAuthorizer($appId);
+
+        $code = 'code@123';
+        $result = $authorizer->getAuthorizationInfo($code);
+
+        $params = [
+            'component_appid'    => $appId,
+            'authorization_code' => $code,
+        ];
+        $this->assertStringStartsWith(Authorizer::GET_AUTH_INFO, $result['api']);
+        $this->assertEquals($params, $result['params']);
+    }
+
+    public function testGetAuthorizationToken()
+    {
+        $appId = 'appid@123';
+        $authorizer = $this->mockAuthorizer($appId);
+
+        $authorizerAppId = 'appid@456';
+        $refreshToken = 'refresh@123';
+        $result = $authorizer->getAuthorizationToken($authorizerAppId, $refreshToken);
+
+        $params = [
+            'component_appid'          => $appId,
+            'authorizer_appid'         => $authorizerAppId,
+            'authorizer_refresh_token' => $refreshToken,
+        ];
+        $this->assertStringStartsWith(Authorizer::GET_AUTHORIZER_TOKEN, $result['api']);
+        $this->assertEquals($params, $result['params']);
+    }
+
+    public function testGetAuthorizerInfo()
+    {
+        $appId = 'appid@123';
+        $authorizer = $this->mockAuthorizer($appId);
+
+        $authorizerAppId = 'appid@456';
+        $result = $authorizer->getAuthorizerInfo($authorizerAppId);
+
+        $params = [
+            'component_appid'  => $appId,
+            'authorizer_appid' => $authorizerAppId,
+        ];
+        $this->assertStringStartsWith(Authorizer::GET_AUTHORIZER_INFO, $result['api']);
+        $this->assertEquals($params, $result['params']);
+    }
+
+    public function testGetAuthorizerOption()
+    {
+        $appId = 'appid@123';
+        $authorizer = $this->mockAuthorizer($appId);
+
+        $authorizerAppId = 'appid@456';
+        $optionName = 'option@123';
+        $result = $authorizer->getAuthorizerOption($authorizerAppId, $optionName);
+
+        $params = [
+            'component_appid'  => $appId,
+            'authorizer_appid' => $authorizerAppId,
+            'option_name'      => $optionName,
+        ];
+        $this->assertStringStartsWith(Authorizer::GET_AUTHORIZER_OPTION, $result['api']);
+        $this->assertEquals($params, $result['params']);
+    }
+
+    public function testSetAuthorizerOption() {
+        $appId = 'appid@123';
+        $authorizer = $this->mockAuthorizer($appId);
+
+        $authorizerAppId = 'appid@456';
+        $optionName = 'option@123';
+        $optionValue = 'value@123';
+        $result = $authorizer->setAuthorizerOption(
+            $authorizerAppId, $optionName, $optionValue);
+
+        $params = [
+            'component_appid'  => $appId,
+            'authorizer_appid' => $authorizerAppId,
+            'option_name' => $optionName,
+            'option_value' => $optionValue,
+        ];
+        $this->assertStringStartsWith(Authorizer::SET_AUTHORIZER_OPTION, $result['api']);
+        $this->assertEquals($params, $result['params']);
+    }
+
+}

--- a/tests/OpenPlatform/AuthorizerTokenTest.php
+++ b/tests/OpenPlatform/AuthorizerTokenTest.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * Test AuthorizerTokenTest.php.
+ *
+ * @author lixiao <leonlx126@gmail.com>
+ */
+
+use EasyWeChat\OpenPlatform\Authorization;
+use EasyWeChat\OpenPlatform\AuthorizerToken;
+
+class AuthorizerTokenTest extends TestCase
+{
+
+    public function testGetToken()
+    {
+        $appId = 'appid@123';
+        $cachedToken = 'token@123';
+        $auth = $this->make($appId, $cachedToken, null);
+
+        $token = $auth->getToken();
+        $this->assertEquals($cachedToken, $token);
+    }
+
+    public function testGetTokenExpired()
+    {
+        $appId = 'appid@123';
+        $newToken = 'token@456';
+        $auth = $this->make($appId, null, $newToken);
+
+        $token = $auth->getToken();
+        $this->assertEquals($newToken, $token);
+    }
+
+    public function testGetTokenForced() {
+        $appId = 'appid@123';
+        $cachedToken = 'token@123';
+        $newToken = 'token@456';
+        $auth = $this->make($appId, $cachedToken, $newToken);
+
+        $token = $auth->getToken(true);
+        $this->assertEquals($newToken, $token);
+    }
+
+    private function make($appId, $cachedToken, $newToken)
+    {
+        /** @var Authorization|\Mockery\MockInterface $mock */
+        $mock = Mockery::mock(Authorization::class);
+        $mock->shouldReceive('getAuthorizerAccessToken')
+             ->andReturn($cachedToken);
+        $mock->shouldReceive('handleAuthorizerAccessToken')
+             ->andReturn($newToken);
+
+        return new AuthorizerToken($appId, $mock);
+    }
+}

--- a/tests/OpenPlatform/GuardTest.php
+++ b/tests/OpenPlatform/GuardTest.php
@@ -79,7 +79,7 @@ class OpenPlatformGuardStub extends Guard
 
     public function getHandlerForTest($type)
     {
-        return $this->getHandler($type);
+        return $this->getDefaultHandler($type);
     }
 
     public function handleMessageForTest()

--- a/tests/OpenPlatform/GuardTest.php
+++ b/tests/OpenPlatform/GuardTest.php
@@ -1,0 +1,90 @@
+<?php
+
+/**
+ * Test GuardTest.php.
+ *
+ * @author lixiao <leonlx126@gmail.com>
+ */
+
+use EasyWeChat\Foundation\Application;
+use EasyWeChat\OpenPlatform\EventHandlers\Authorized;
+use EasyWeChat\OpenPlatform\EventHandlers\ComponentVerifyTicket;
+use EasyWeChat\OpenPlatform\EventHandlers\EventHandler;
+use EasyWeChat\OpenPlatform\EventHandlers\Unauthorized;
+use EasyWeChat\OpenPlatform\EventHandlers\UpdateAuthorized;
+use EasyWeChat\OpenPlatform\Guard;
+use EasyWeChat\Support\Collection;
+
+class GuardTest extends TestCase
+{
+
+    public function testGetHandler()
+    {
+        $server = $this->make();
+
+        $handlers = [
+            Guard::EVENT_AUTHORIZED              => Authorized::class,
+            Guard::EVENT_UNAUTHORIZED            => Unauthorized::class,
+            Guard::EVENT_UPDATE_AUTHORIZED       => UpdateAuthorized::class,
+            Guard::EVENT_COMPONENT_VERIFY_TICKET => ComponentVerifyTicket::class,
+        ];
+
+        foreach ($handlers as $type => $handler) {
+            $this->assertInstanceOf($handler, $server->getHandlerForTest($type));
+        }
+    }
+
+    public function testHandleMessage()
+    {
+        $server = $this->make();
+        $result = $server->handleMessageForTest();
+
+        $this->assertEquals(OpenPlatformGuardStub::$message, $result);
+    }
+
+    private function make()
+    {
+        $config = [
+            'open_platform' => [
+                'app_id'  => 'your-app-id',
+                'secret'  => 'your-app-secret',
+                'token'   => 'your-token',
+                'aes_key' => 'your-ase-key',
+            ],
+        ];
+
+        $app = new Application($config);
+
+        $server = new OpenPlatformGuardStub('token');
+        $server->setContainer($app);
+
+        $app['open_platform_handle_test']
+            = Mockery::mock(EventHandler::class)
+                     ->shouldReceive('handle')
+                     ->andReturnUsing(
+                         function (Collection $message) {
+                             return $message->all();
+                         }
+                     )
+                     ->mock();
+
+        return $server;
+    }
+}
+
+class OpenPlatformGuardStub extends Guard
+{
+
+    public static $message = ['InfoType' => 'test'];
+
+    public function getHandlerForTest($type)
+    {
+        return $this->getHandler($type);
+    }
+
+    public function handleMessageForTest()
+    {
+        return $this->handleMessage(self::$message);
+    }
+
+}

--- a/tests/OpenPlatform/GuardTest.php
+++ b/tests/OpenPlatform/GuardTest.php
@@ -58,7 +58,7 @@ class GuardTest extends TestCase
         $server = new OpenPlatformGuardStub('token');
         $server->setContainer($app);
 
-        $app['open_platform_handle_test']
+        $app['open_platform.handlers.test']
             = Mockery::mock(EventHandler::class)
                      ->shouldReceive('handle')
                      ->andReturnUsing(

--- a/tests/OpenPlatform/OpenPlatformTest.php
+++ b/tests/OpenPlatform/OpenPlatformTest.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * Test OpenPlatformTest.php.
+ *
+ * @author lixiao <leonlx126@gmail.com>
+ */
+
+use EasyWeChat\Foundation\Application;
+use EasyWeChat\OpenPlatform\Components\Authorizer;
+use EasyWeChat\OpenPlatform\Components\PreAuthCode;
+use EasyWeChat\OpenPlatform\Guard;
+
+class OpenPlatformTest extends TestCase {
+
+    public function testOpenPlatform()
+    {
+        $app = $this->make();
+
+        $this->assertInstanceOf(Authorizer::class, $app->open_platform->authorizer);
+        $this->assertInstanceOf(PreAuthCode::class, $app->open_platform->pre_auth);
+        $this->assertInstanceOf(Guard::class, $app->open_platform->server);
+    }
+
+    /**
+     * Makes application.
+     *
+     * @return Application
+     */
+    private function make()
+    {
+        $config = [
+            'open_platform' => [
+                'app_id'  => 'your-app-id',
+                'secret'  => 'your-app-secret',
+                'token'   => 'your-token',
+                'aes_key' => 'your-ase-key',
+            ],
+        ];
+
+        return new Application($config);
+    }
+
+}

--- a/tests/OpenPlatform/PreAuthCodeTest.php
+++ b/tests/OpenPlatform/PreAuthCodeTest.php
@@ -1,0 +1,79 @@
+<?php
+
+/**
+ * Test PreAuthCodeTest.php.
+ *
+ * @author lixiao <leonlx126@gmail.com>
+ */
+
+use EasyWeChat\OpenPlatform\AccessToken;
+use EasyWeChat\OpenPlatform\Components\PreAuthCode;
+
+class PreAuthCodeTest extends TestCase {
+
+    /**
+     * PreAuthCode mock.
+     *
+     * @param string $appId
+     * @param string $code
+     *
+     * @return \Mockery\MockInterface|PreAuthCode
+     */
+    public function mockPreAuth($appId, $code = null)
+    {
+        $preAuth = Mockery::mock(
+            PreAuthCode::class . '[parseJSON]',
+            [
+                Mockery::mock(AccessToken::class),
+                ['open_platform' => ['app_id' => $appId]],
+            ]
+        );
+
+        /** @noinspection PhpUnusedParameterInspection */
+        $preAuth
+            ->shouldReceive('parseJSON')
+            ->andReturnUsing(function ($method, $params) use ($code) {
+                return [
+                    'api'           => $params[0],
+                    'params'        => empty($params[1]) ? null : $params[1],
+                    'pre_auth_code' => $code,
+                ];
+            });
+
+        return $preAuth;
+    }
+
+    public function testGetAppId()
+    {
+        $appId = 'appid@foobar';
+        $this->assertEquals($appId, $this->mockPreAuth($appId)->getAppId());
+    }
+
+    public function testGetCode()
+    {
+        $appId = 'appid@foobar';
+        $code = 'code@foobar';
+        $preAuth = $this->mockPreAuth($appId, $code);
+
+        /** @var PreAuthCode $preAuth */
+        $result = $preAuth->getCode();
+
+        $this->assertEquals($code, $result);
+    }
+
+    public function testGetAuthLink()
+    {
+        $appId = 'appid@foobar';
+        $code = 'code@foobar';
+        $redirect = 'http://domain.com/foo/bar';
+        $preAuth = $this->mockPreAuth($appId, $code)
+                        ->setRedirectUri($redirect);
+
+        $link = sprintf(
+            PreAuthCode::PRE_AUTH_LINK,
+            $appId, $code, 'http%3a%2f%2fdomain.com%2ffoo%2fbar'
+        );
+
+        $this->assertEquals($link, strtolower($preAuth->getAuthLink()));
+    }
+}

--- a/tests/OpenPlatform/VerifyTicketTest.php
+++ b/tests/OpenPlatform/VerifyTicketTest.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * Test VerifyTicketTest.php.
+ *
+ * @author lixiao <leonlx126@gmail.com>
+ */
+
+use Doctrine\Common\Cache\ArrayCache;
+use EasyWeChat\OpenPlatform\VerifyTicket;
+use EasyWeChat\Support\Collection;
+
+class VerifyTicketTest extends TestCase {
+
+    /**
+     * Tests that the verify ticket is properly cached.
+     */
+    public function testCache() {
+        $appId = 'foobar';
+        $cache = new ArrayCache();
+        $verifyTicket = new VerifyTicket($appId, $cache);
+
+        $ticket = 'ticket@foobar';
+        $message = new Collection(['ComponentVerifyTicket' => $ticket]);
+
+        $ok = $verifyTicket->cache($message);
+        $this->assertTrue($ok);
+
+        $cached = $verifyTicket->getTicket();
+        $this->assertEquals($ticket, $cached);
+    }
+}

--- a/tests/OpenPlatform/stubs/authorization_all.json
+++ b/tests/OpenPlatform/stubs/authorization_all.json
@@ -1,0 +1,46 @@
+{
+    "authorization_info": {
+        "authorizer_appid": "wxf8b4f85f3a794e77",
+        "authorizer_access_token": "QXjUqNqfYVH0yBE1iI_7vuN_9gQbpjfK7hYwJ3P7xOa88a89-Aga5x1NMYJyB8G2yKt1KCl0nPC3W9GJzw0Zzq_dBxc8pxIGUNi_bFes0qM",
+        "expires_in": 7200,
+        "authorizer_refresh_token": "dTo-YCXPL4llX-u1W1pPpnp8Hgm4wpJtlR6iV0doKdY",
+        "func_info": [
+            {
+                "funcscope_category": {
+                    "id": 1
+                }
+            },
+            {
+                "funcscope_category": {
+                    "id": 2
+                }
+            },
+            {
+                "funcscope_category": {
+                    "id": 3
+                }
+            }
+        ]
+    },
+    "authorizer_info": {
+        "nick_name": "微信SDK Demo Special",
+        "head_img": "http://wx.qlogo.cn/mmopen/GPy",
+        "service_type_info": {
+            "id": 2
+        },
+        "verify_type_info": {
+            "id": 0
+        },
+        "user_name": "gh_eb5e3a772040",
+        "principal_name": "腾讯计算机系统有限公司",
+        "business_info": {
+            "open_store": 0,
+            "open_scan": 0,
+            "open_pay": 0,
+            "open_card": 0,
+            "open_shake": 0
+        },
+        "alias": "paytest01",
+        "qrcode_url": "URL"
+    }
+}

--- a/tests/OpenPlatform/stubs/authorization_info.json
+++ b/tests/OpenPlatform/stubs/authorization_info.json
@@ -1,0 +1,25 @@
+{
+    "authorization_info": {
+        "authorizer_appid": "wxf8b4f85f3a794e77",
+        "authorizer_access_token": "QXjUqNqfYVH0yBE1iI_7vuN_9gQbpjfK7hYwJ3P7xOa88a89-Aga5x1NMYJyB8G2yKt1KCl0nPC3W9GJzw0Zzq_dBxc8pxIGUNi_bFes0qM",
+        "expires_in": 7200,
+        "authorizer_refresh_token": "dTo-YCXPL4llX-u1W1pPpnp8Hgm4wpJtlR6iV0doKdY",
+        "func_info": [
+            {
+                "funcscope_category": {
+                    "id": 1
+                }
+            },
+            {
+                "funcscope_category": {
+                    "id": 2
+                }
+            },
+            {
+                "funcscope_category": {
+                    "id": 3
+                }
+            }
+        ]
+    }
+}

--- a/tests/OpenPlatform/stubs/authorizer_info.json
+++ b/tests/OpenPlatform/stubs/authorizer_info.json
@@ -1,0 +1,43 @@
+{
+    "authorizer_info": {
+        "nick_name": "微信SDK Demo Special",
+        "head_img": "http://wx.qlogo.cn/mmopen/GPy",
+        "service_type_info": {
+            "id": 2
+        },
+        "verify_type_info": {
+            "id": 0
+        },
+        "user_name": "gh_eb5e3a772040",
+        "principal_name": "腾讯计算机系统有限公司",
+        "business_info": {
+            "open_store": 0,
+            "open_scan": 0,
+            "open_pay": 0,
+            "open_card": 0,
+            "open_shake": 0
+        },
+        "alias": "paytest01",
+        "qrcode_url": "URL"
+    },
+    "authorization_info": {
+        "appid": "wxf8b4f85f3a794e77",
+        "func_info": [
+            {
+                "funcscope_category": {
+                    "id": 1
+                }
+            },
+            {
+                "funcscope_category": {
+                    "id": 2
+                }
+            },
+            {
+                "funcscope_category": {
+                    "id": 3
+                }
+            }
+        ]
+    }
+}

--- a/tests/OpenPlatform/stubs/authorizer_token.json
+++ b/tests/OpenPlatform/stubs/authorizer_token.json
@@ -1,0 +1,5 @@
+{
+    "authorizer_access_token": "aaUl5s6kAByLwgV0BhXNuIFFUqfrR8vTATsoSHukcIGqJgrc4KmMJ-JlKoC_-NKCLBvuU1cWPv4vDcLN8Z0pn5I45mpATruU0b51hzeT1f8",
+    "expires_in": 7200,
+    "authorizer_refresh_token": "BstnRqgTJBXb9N2aJq6L5hzfJwP406tpfahQeLNxX0w"
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -3,3 +3,4 @@
 include __DIR__.'/../vendor/autoload.php';
 
 include __DIR__.'/TestCase.php';
+include __DIR__.'/OpenPlatform/AuthorizationTest.php';


### PR DESCRIPTION
重构的原因是因为不好用。。。

原来的只是封装了 API 的调用，缓存了 `component_verify_ticket`，但对于授权和授权方的信息没有做任何处理，尤其是 `authorizer_access_token` 和 `authorizer_refresh_token` 的缓存。

因为第三方平台须要使用 `authorizer_access_token` 来调用各 API，`authorizer_access_token` 又须要 `authorizer_refresh_token` 来刷新，`authorizer_refresh_token` 又要通过授权才能获得，要进行授权又要先有 `component_verify_ticket` 和 `component_access_token`  ... 说多了都是泪 ...

此重构的主要目的就是想封装掉 `authorizer_access_token` 和 `authorizer_refresh_token` 的获取和缓存。

主要重构内容:

1. 尽量使用 `Container` 来获取实例而不是直接 `new`，主要修改在 `OpenPlatformServiceProvider` 和 `OpenPlatform\Guard` 两个类上。
2. 修改各种 token 的缓存 key 为 `easywechat.open_platform.*`。
3. 重构 4 个` EventHandler`，分别处理授权成功，授权更新，授权取消和 verify ticket。
4. 添加 `AuthorizerToken` 用来替换原 `AccessToken` 来调用 API。
5. 添加了单元测试。

中英文文档随后会另外提交。