### PR TITLE
Update OpenPlatform AppId

### DIFF
--- a/src/OpenPlatform/AuthorizerToken.php
+++ b/src/OpenPlatform/AuthorizerToken.php
@@ -82,4 +82,14 @@ class AuthorizerToken extends BaseAccessToken
 
         return $cached;
     }
+
+    /**
+     * Get AppId for Authorizer.
+     *
+     * @return string
+     */
+    public function getAppId()
+    {
+        return $this->authorization->getAuthorizerAppId();
+    }
 }


### PR DESCRIPTION
使用第三方平台授权来生成JS-SDK签名时，返回的 appid 是第三方平台的，应该改为授权方的 appid 才对。