### PR TITLE
修复新建卡券时 填写高级信息后的 "解析JSON/XML内容错误"

### DIFF
--- a/src/Card/Card.php
+++ b/src/Card/Card.php
@@ -110,7 +110,7 @@ class Card extends AbstractAPI
         $params = [
             'card' => [
                 'card_type' => strtoupper($cardType),
-                strtolower($cardType) => array_merge(['base_info' => $baseInfo], $especial, $advancedInfo),
+                strtolower($cardType) => array_merge(['base_info' => $baseInfo], $especial, ['advanced_info' => $advancedInfo]),
             ],
         ];
 


### PR DESCRIPTION
详见

[微信官方最新的创建卡券时的数据格式](https://mp.weixin.qq.com/wiki?action=doc&id=mp1451025056&t=0.38432438874149155#2.6)