### PR TITLE
修复一个创建卡券时的 bug, 添加获取微信门店类目表的api

### DIFF
--- a/src/Card/Card.php
+++ b/src/Card/Card.php
@@ -110,7 +110,7 @@ class Card extends AbstractAPI
         $params = [
             'card' => [
                 'card_type' => strtoupper($cardType),
-                strtolower($cardType) => array_merge(['base_info' => $baseInfo], $especial, $advancedInfo),
+                strtolower($cardType) => array_merge(['base_info' => $baseInfo], $especial, ['advanced_info' => $advancedInfo]),
             ],
         ];
 

--- a/src/POI/POI.php
+++ b/src/POI/POI.php
@@ -33,6 +33,17 @@ class POI extends AbstractAPI
     const API_LIST = 'http://api.weixin.qq.com/cgi-bin/poi/getpoilist';
     const API_UPDATE = 'http://api.weixin.qq.com/cgi-bin/poi/updatepoi';
     const API_DELETE = 'http://api.weixin.qq.com/cgi-bin/poi/delpoi';
+    const API_GET_CATEGORIES = 'http://api.weixin.qq.com/cgi-bin/poi/getwxcategory';
+
+    /**
+     * Get POI supported categories.
+     *
+     * @return \EasyWeChat\Support\Collection
+     */
+    public function getCategories()
+    {
+        return $this->parseJSON('get', [self::API_GET_CATEGORIES]);
+    }
 
     /**
      * Get POI by ID.

--- a/tests/POI/POIPOITest.php
+++ b/tests/POI/POIPOITest.php
@@ -27,6 +27,17 @@ class POIPOITest extends TestCase
     }
 
     /**
+     * Test getCategories().
+     */
+    public function testGetCategories()
+    {
+        $POI = $this->getPOI();
+
+        $response = $POI->getCategories();
+        $this->assertStringStartsWith(POI::API_GET_CATEGORIES, $response['api']);
+    }
+
+    /**
      * Test get().
      */
     public function testGet()


### PR DESCRIPTION
修复新建卡券时, 填写高级信息时的字段缺失

添加获取微信支持的门店类目表 