### PR TITLE
Support Payment Sandbox mode

### DIFF
--- a/src/Payment/API.php
+++ b/src/Payment/API.php
@@ -38,18 +38,27 @@ class API extends AbstractAPI
      */
     protected $merchant;
 
+    /**
+     * Sandbox box mode.
+     *
+     * @var bool
+     */
+    protected $sandboxEnabled = false;
+
+    const API_HOST = 'https://api.mch.weixin.qq.com';
+
     // api
-    const API_PAY_ORDER = 'https://api.mch.weixin.qq.com/pay/micropay';
-    const API_PREPARE_ORDER = 'https://api.mch.weixin.qq.com/pay/unifiedorder';
-    const API_QUERY = 'https://api.mch.weixin.qq.com/pay/orderquery';
-    const API_CLOSE = 'https://api.mch.weixin.qq.com/pay/closeorder';
-    const API_REVERSE = 'https://api.mch.weixin.qq.com/secapi/pay/reverse';
-    const API_REFUND = 'https://api.mch.weixin.qq.com/secapi/pay/refund';
-    const API_QUERY_REFUND = 'https://api.mch.weixin.qq.com/pay/refundquery';
-    const API_DOWNLOAD_BILL = 'https://api.mch.weixin.qq.com/pay/downloadbill';
-    const API_REPORT = 'https://api.mch.weixin.qq.com/payitil/report';
-    const API_URL_SHORTEN = 'https://api.mch.weixin.qq.com/tools/shorturl';
-    const API_AUTH_CODE_TO_OPENID = 'https://api.mch.weixin.qq.com/tools/authcodetoopenid';
+    const API_PAY_ORDER = '/pay/micropay';
+    const API_PREPARE_ORDER = '/pay/unifiedorder';
+    const API_QUERY = '/pay/orderquery';
+    const API_CLOSE = '/pay/closeorder';
+    const API_REVERSE = '/secapi/pay/reverse';
+    const API_REFUND = '/secapi/pay/refund';
+    const API_QUERY_REFUND = '/pay/refundquery';
+    const API_DOWNLOAD_BILL = '/pay/downloadbill';
+    const API_REPORT = '/payitil/report';
+    const API_URL_SHORTEN = '/tools/shorturl';
+    const API_AUTH_CODE_TO_OPENID = '/tools/authcodetoopenid';
 
     // order id types.
     const TRANSACTION_ID = 'transaction_id';
@@ -82,7 +91,7 @@ class API extends AbstractAPI
      */
     public function pay(Order $order)
     {
-        return $this->request(self::API_PAY_ORDER, $order->all());
+        return $this->request($this->wrapApi(self::API_PAY_ORDER), $order->all());
     }
 
     /**
@@ -99,7 +108,7 @@ class API extends AbstractAPI
             $order->spbill_create_ip = ($order->trade_type === Order::NATIVE) ? get_server_ip() : get_client_ip();
         }
 
-        return $this->request(self::API_PREPARE_ORDER, $order->all());
+        return $this->request($this->wrapApi(self::API_PREPARE_ORDER), $order->all());
     }
 
     /**
@@ -116,7 +125,7 @@ class API extends AbstractAPI
             $type => $orderNo,
         ];
 
-        return $this->request(self::API_QUERY, $params);
+        return $this->request($this->wrapApi(self::API_QUERY), $params);
     }
 
     /**
@@ -144,7 +153,7 @@ class API extends AbstractAPI
             'out_trade_no' => $tradeNo,
         ];
 
-        return $this->request(self::API_CLOSE, $params);
+        return $this->request($this->wrapApi(self::API_CLOSE), $params);
     }
 
     /**
@@ -161,7 +170,7 @@ class API extends AbstractAPI
             $type => $orderNo,
         ];
 
-        return $this->safeRequest(self::API_REVERSE, $params);
+        return $this->safeRequest($this->wrapApi(self::API_REVERSE), $params);
     }
 
     /**
@@ -207,7 +216,7 @@ class API extends AbstractAPI
             'op_user_id' => $opUserId ?: $this->merchant->merchant_id,
         ];
 
-        return $this->safeRequest(self::API_REFUND, $params);
+        return $this->safeRequest($this->wrapApi(self::API_REFUND), $params);
     }
 
     /**
@@ -246,7 +255,7 @@ class API extends AbstractAPI
             $type => $orderNo,
         ];
 
-        return $this->request(self::API_QUERY_REFUND, $params);
+        return $this->request($this->wrapApi(self::API_QUERY_REFUND), $params);
     }
 
     /**
@@ -300,7 +309,7 @@ class API extends AbstractAPI
             'bill_type' => $type,
         ];
 
-        return $this->request(self::API_DOWNLOAD_BILL, $params, 'post', [\GuzzleHttp\RequestOptions::STREAM => true], true)->getBody();
+        return $this->request($this->wrapApi(self::API_DOWNLOAD_BILL), $params, 'post', [\GuzzleHttp\RequestOptions::STREAM => true], true)->getBody();
     }
 
     /**
@@ -312,7 +321,7 @@ class API extends AbstractAPI
      */
     public function urlShorten($url)
     {
-        return $this->request(self::API_URL_SHORTEN, ['long_url' => $url]);
+        return $this->request($this->wrapApi(self::API_URL_SHORTEN), ['long_url' => $url]);
     }
 
     /**
@@ -338,7 +347,7 @@ class API extends AbstractAPI
             'time' => time(),
         ], $other);
 
-        return $this->request(self::API_REPORT, $params);
+        return $this->request($this->wrapApi(self::API_REPORT), $params);
     }
 
     /**
@@ -350,7 +359,7 @@ class API extends AbstractAPI
      */
     public function authCodeToOpenId($authCode)
     {
-        return $this->request(self::API_AUTH_CODE_TO_OPENID, ['auth_code' => $authCode]);
+        return $this->request($this->wrapApi(self::API_AUTH_CODE_TO_OPENID), ['auth_code' => $authCode]);
     }
 
     /**
@@ -439,5 +448,25 @@ class API extends AbstractAPI
         }
 
         return new Collection((array) XML::parse($response));
+    }
+
+    /**
+     * Set sandbox mode.
+     *
+     * @param bool $enabled
+     */
+    public function sandboxMode($enabled = false)
+    {
+        $this->sandboxEnabled = $enabled;
+    }
+
+    /**
+     * Wrap sandbox API.
+     *
+     * @param string $resource
+     */
+    public function wrapApi($resource)
+    {
+        return self::API_HOST.($this->sandboxEnabled ? '/sandbox' : '').$resource;
     }
 }

--- a/src/Payment/API.php
+++ b/src/Payment/API.php
@@ -465,7 +465,7 @@ class API extends AbstractAPI
      *
      * @param string $resource
      */
-    public function wrapApi($resource)
+    protected function wrapApi($resource)
     {
         return self::API_HOST.($this->sandboxEnabled ? '/sandbox' : '').$resource;
     }

--- a/tests/Payment/PaymentAPITest.php
+++ b/tests/Payment/PaymentAPITest.php
@@ -45,7 +45,7 @@ class PaymentAPITest extends TestCase
                 'notify_url' => 'merchant_default_notify_url',
             ]);
 
-        $api = \Mockery::mock('EasyWeChat\Payment\API[getHttp]', [$merchant]);
+        $api = \Mockery::mock('EasyWeChat\Payment\API[getHttp]', [$merchant])->shouldAllowMockingProtectedMethods();
         $api->shouldReceive('getHttp')->andReturn($http);
 
         return $api;

--- a/tests/Payment/PaymentAPITest.php
+++ b/tests/Payment/PaymentAPITest.php
@@ -63,7 +63,7 @@ class PaymentAPITest extends TestCase
 
         $response = $api->prepare($order);
 
-        $this->assertEquals(API::API_PREPARE_ORDER, $response['api']);
+        $this->assertEquals($api->wrapApi(API::API_PREPARE_ORDER), $response['api']);
         $this->assertEquals('wxTestAppId', $response['params']['appid']);
         $this->assertEquals('merchant_default_notify_url', $response['params']['notify_url']);
         $this->assertEquals('testMerchantId', $response['params']['mch_id']);
@@ -82,7 +82,7 @@ class PaymentAPITest extends TestCase
 
         $response = $api->pay($order);
 
-        $this->assertEquals(API::API_PAY_ORDER, $response['api']);
+        $this->assertEquals($api->wrapApi(API::API_PAY_ORDER), $response['api']);
         $this->assertEquals('wxTestAppId', $response['params']['appid']);
         $this->assertEquals('testMerchantId', $response['params']['mch_id']);
         $this->assertEquals('bar', $response['params']['foo']);
@@ -96,16 +96,16 @@ class PaymentAPITest extends TestCase
         $api = $this->getAPI();
         $response = $api->query('testTradeNoFoo');
 
-        $this->assertEquals(API::API_QUERY, $response['api']);
+        $this->assertEquals($api->wrapApi(API::API_QUERY), $response['api']);
         $this->assertEquals('testTradeNoFoo', $response['params']['out_trade_no']);
 
         $response = $api->query('testTradeNoBar', API::TRANSACTION_ID);
 
-        $this->assertEquals(API::API_QUERY, $response['api']);
+        $this->assertEquals($api->wrapApi(API::API_QUERY), $response['api']);
         $this->assertEquals('testTradeNoBar', $response['params']['transaction_id']);
 
         $response = $api->queryByTransactionId('testTransactionId');
-        $this->assertEquals(API::API_QUERY, $response['api']);
+        $this->assertEquals($api->wrapApi(API::API_QUERY), $response['api']);
         $this->assertEquals('testTransactionId', $response['params']['transaction_id']);
     }
 
@@ -117,7 +117,7 @@ class PaymentAPITest extends TestCase
         $api = $this->getAPI();
 
         $response = $api->close('testTradeNo');
-        $this->assertEquals(API::API_CLOSE, $response['api']);
+        $this->assertEquals($api->wrapApi(API::API_CLOSE), $response['api']);
         $this->assertEquals('testTradeNo', $response['params']['out_trade_no']);
     }
 
@@ -129,11 +129,11 @@ class PaymentAPITest extends TestCase
         $api = $this->getAPI();
 
         $response = $api->reverse('testTradeNo');
-        $this->assertEquals(API::API_REVERSE, $response['api']);
+        $this->assertEquals($api->wrapApi(API::API_REVERSE), $response['api']);
         $this->assertEquals('testTradeNo', $response['params']['out_trade_no']);
 
         $response = $api->reverse('testTransactionId', API::TRANSACTION_ID);
-        $this->assertEquals(API::API_REVERSE, $response['api']);
+        $this->assertEquals($api->wrapApi(API::API_REVERSE), $response['api']);
         $this->assertEquals('testTransactionId', $response['params']['transaction_id']);
     }
 
@@ -145,7 +145,7 @@ class PaymentAPITest extends TestCase
         $api = $this->getAPI();
 
         $response = $api->refund('testTradeNo', 'testRefundNo', 100);
-        $this->assertEquals(API::API_REFUND, $response['api']);
+        $this->assertEquals($api->wrapApi(API::API_REFUND), $response['api']);
         $this->assertEquals('testRefundNo', $response['params']['out_refund_no']);
         $this->assertEquals(100, $response['params']['total_fee']);
         $this->assertEquals(100, $response['params']['refund_fee']);
@@ -172,11 +172,11 @@ class PaymentAPITest extends TestCase
         $api = $this->getAPI();
 
         $response = $api->queryRefund('testTradeNo');
-        $this->assertEquals(API::API_QUERY_REFUND, $response['api']);
+        $this->assertEquals($api->wrapApi(API::API_QUERY_REFUND), $response['api']);
         $this->assertEquals('testTradeNo', $response['params']['out_trade_no']);
 
         $response = $api->queryRefund('testTransactionId', API::TRANSACTION_ID);
-        $this->assertEquals(API::API_QUERY_REFUND, $response['api']);
+        $this->assertEquals($api->wrapApi(API::API_QUERY_REFUND), $response['api']);
         $this->assertEquals('testTransactionId', $response['params']['transaction_id']);
     }
 
@@ -208,12 +208,12 @@ class PaymentAPITest extends TestCase
         $api->shouldReceive('getHttp')->andReturn($http);
 
         $response = $api->downloadBill('20150901');
-        $this->assertEquals(API::API_DOWNLOAD_BILL, $response['api']);
+        $this->assertEquals($api->wrapApi(API::API_DOWNLOAD_BILL), $response['api']);
         $this->assertEquals('20150901', $response['params']['bill_date']);
         $this->assertEquals(API::BILL_TYPE_ALL, $response['params']['bill_type']);
 
         $response = $api->downloadBill('20150901', API::BILL_TYPE_SUCCESS);
-        $this->assertEquals(API::API_DOWNLOAD_BILL, $response['api']);
+        $this->assertEquals($api->wrapApi(API::API_DOWNLOAD_BILL), $response['api']);
         $this->assertEquals('20150901', $response['params']['bill_date']);
         $this->assertEquals(API::BILL_TYPE_SUCCESS, $response['params']['bill_type']);
     }
@@ -227,7 +227,7 @@ class PaymentAPITest extends TestCase
 
         $response = $api->urlShorten('http://easywechat.org');
 
-        $this->assertEquals(API::API_URL_SHORTEN, $response['api']);
+        $this->assertEquals($api->wrapApi(API::API_URL_SHORTEN), $response['api']);
         $this->assertEquals('http://easywechat.org', $response['params']['long_url']);
     }
 
@@ -240,7 +240,7 @@ class PaymentAPITest extends TestCase
 
         $response = $api->authCodeToOpenId('authcode');
 
-        $this->assertEquals(API::API_AUTH_CODE_TO_OPENID, $response['api']);
+        $this->assertEquals($api->wrapApi(API::API_AUTH_CODE_TO_OPENID), $response['api']);
         $this->assertEquals('authcode', $response['params']['auth_code']);
     }
 


### PR DESCRIPTION
Following discussion from https://github.com/overtrue/wechat/issues/507

This PR adds the feature. So, app user can set sandbox mode like this:
```
$app = new Application($options);
$wechat_pay = $app->payment;
$wechat_pay->enableSandbox(true);
```

Another option to enable to sandbox can be in `$option`:

```
    $options = [
      // 前面的appid什么的也得保留哦
      'app_id' => $appid,
      // ...
      // payment
      'payment' => [
        'merchant_id'        => $mch_id,
        'key'                => $key,
        'cert_path'          => 'path/to/your/cert.pem', // XXX: 绝对路径！！！！
        'key_path'           => 'path/to/your/key',      // XXX: 绝对路径！！！！
        'notify_url'         => $payment_gateway_plugin->getNotifyUrl()->toString(),
         'device_info'     => '013467007045764',
         'sub_app_id'      => '',
         'sub_merchant_id' => '',
         'sandbox_mode' => true,
        // ...
      ],
    ];
```
But, this PR does't include the second way. Further contribution is welcomed.

Comparing to the PR https://github.com/overtrue/wechat/pull/657, this PR uses Github forking and patching best practice, and squashed the commits into one.