### PR TITLE
Avoid ambiguity

### DIFF
--- a/src/OpenPlatform/Api/BaseApi.php
+++ b/src/OpenPlatform/Api/BaseApi.php
@@ -76,7 +76,7 @@ class BaseApi extends AbstractOpenPlatform
      *
      * It doesn't cache the authorizer-access-token.
      * So developers should NEVER call this method.
-     * It'll called by: AuthorizerAccessToken::refreshToken()
+     * It'll called by: AuthorizerAccessToken::renewAccessToken()
      *
      * @param $appId
      * @param $refreshToken

--- a/src/OpenPlatform/AuthorizerAccessToken.php
+++ b/src/OpenPlatform/AuthorizerAccessToken.php
@@ -72,7 +72,7 @@ class AuthorizerAccessToken extends BaseAccessToken
         $cached = $this->authorizer->getAccessToken();
 
         if ($forceRefresh || empty($cached)) {
-            return $this->refreshToken();
+            return $this->renewAccessToken();
         }
 
         return $cached;
@@ -83,7 +83,7 @@ class AuthorizerAccessToken extends BaseAccessToken
      *
      * @return string
      */
-    protected function refreshToken()
+    protected function renewAccessToken()
     {
         $token = $this->authorizer->getApi()
             ->getAuthorizerToken(


### PR DESCRIPTION
Rename method name in order to avoid ambiguity.