### PR TITLE
Fix endless loop.

### DIFF
--- a/src/Payment/API.php
+++ b/src/Payment/API.php
@@ -460,7 +460,7 @@ class API extends AbstractAPI
      */
     protected function generateSign($params)
     {
-        $key = $this->sandboxEnabled ? $this->getSandboxSignKey() : $this->merchant->key;
+        $key = ($this->sandboxEnabled && $this->sandboxSignKey) ? $this->getSandboxSignKey() : $this->merchant->key;
 
         return generate_sign($params, $key, 'md5');
     }


### PR DESCRIPTION
我们得检查 `$this->sandboxSignKey` 是否存在，如果不存在，就算是sandbox mode, 也不可以`$this->getSandboxSignKey()`， 不然，就死循环了。