### PR TITLE
Add the ability to set notify_url when prepare an order.

### DIFF
--- a/src/Payment/API.php
+++ b/src/Payment/API.php
@@ -120,11 +120,12 @@ class API extends AbstractAPI
      *
      * @param Order $order
      *
+     * @param $notify_url
      * @return \EasyWeChat\Support\Collection
      */
-    public function prepare(Order $order)
+    public function prepare(Order $order, $notify_url = null)
     {
-        $order->notify_url = $order->get('notify_url', $this->merchant->notify_url);
+        $notify_url ? $order->notify_url = $notify_url : $order->notify_url = $order->get('notify_url', $this->merchant->notify_url);
         if (is_null($order->spbill_create_ip)) {
             $order->spbill_create_ip = ($order->trade_type === Order::NATIVE) ? get_server_ip() : get_client_ip();
         }


### PR DESCRIPTION
一些应用, 当创建应用基本信息的时候并不一定知道 notify_url，这个PR提供一个较为方便的方法让应用可以在`prepare`的时候设置notify_url 或者 覆盖之前设置好的 notify_url。