### PR TITLE
修正素材管理中的返回值文档注释，正确的类型应该是集合，而不是字符串。

### DIFF
--- a/src/OfficialAccount/Material/Material.php
+++ b/src/OfficialAccount/Material/Material.php
@@ -51,7 +51,7 @@ class Material extends AbstractAPI
      *
      * @param string $path
      *
-     * @return string
+     * @return \EasyWeChat\Support\Collection
      */
     public function uploadImage($path)
     {
@@ -63,7 +63,7 @@ class Material extends AbstractAPI
      *
      * @param string $path
      *
-     * @return string
+     * @return \EasyWeChat\Support\Collection
      */
     public function uploadVoice($path)
     {
@@ -75,7 +75,7 @@ class Material extends AbstractAPI
      *
      * @param string $path
      *
-     * @return string
+     * @return \EasyWeChat\Support\Collection
      */
     public function uploadThumb($path)
     {
@@ -89,7 +89,7 @@ class Material extends AbstractAPI
      * @param string $title
      * @param string $description
      *
-     * @return string
+     * @return \EasyWeChat\Support\Collection
      */
     public function uploadVideo($path, $title, $description)
     {
@@ -109,7 +109,7 @@ class Material extends AbstractAPI
      *
      * @param array|Article $articles
      *
-     * @return string
+     * @return \EasyWeChat\Support\Collection
      */
     public function uploadArticle($articles)
     {
@@ -138,7 +138,7 @@ class Material extends AbstractAPI
      * @param array  $article
      * @param int    $index
      *
-     * @return bool
+     * @return \EasyWeChat\Support\Collection
      */
     public function updateArticle($mediaId, $article, $index = 0)
     {
@@ -156,7 +156,7 @@ class Material extends AbstractAPI
      *
      * @param string $path
      *
-     * @return string
+     * @return \EasyWeChat\Support\Collection
      */
     public function uploadArticleImage($path)
     {
@@ -197,7 +197,7 @@ class Material extends AbstractAPI
      *
      * @param string $mediaId
      *
-     * @return bool
+     * @return \EasyWeChat\Support\Collection
      */
     public function delete($mediaId)
     {
@@ -255,7 +255,7 @@ class Material extends AbstractAPI
      * @param string $path
      * @param array  $form
      *
-     * @return string
+     * @return \EasyWeChat\Support\Collection
      *
      * @throws InvalidArgumentException
      */

--- a/src/OfficialAccount/Material/Temporary.php
+++ b/src/OfficialAccount/Material/Temporary.php
@@ -90,7 +90,7 @@ class Temporary extends AbstractAPI
      * @param string $type
      * @param string $path
      *
-     * @return string
+     * @return \EasyWeChat\Support\Collection
      *
      * @throws \EasyWeChat\Exceptions\InvalidArgumentException
      */
@@ -112,7 +112,7 @@ class Temporary extends AbstractAPI
      *
      * @param $path
      *
-     * @return string
+     * @return \EasyWeChat\Support\Collection
      *
      * @throws \EasyWeChat\Exceptions\InvalidArgumentException
      */
@@ -126,7 +126,7 @@ class Temporary extends AbstractAPI
      *
      * @param $path
      *
-     * @return string
+     * @return \EasyWeChat\Support\Collection
      *
      * @throws \EasyWeChat\Exceptions\InvalidArgumentException
      */
@@ -140,7 +140,7 @@ class Temporary extends AbstractAPI
      *
      * @param $path
      *
-     * @return string
+     * @return \EasyWeChat\Support\Collection
      *
      * @throws \EasyWeChat\Exceptions\InvalidArgumentException
      */
@@ -154,7 +154,7 @@ class Temporary extends AbstractAPI
      *
      * @param $path
      *
-     * @return string
+     * @return \EasyWeChat\Support\Collection
      *
      * @throws \EasyWeChat\Exceptions\InvalidArgumentException
      */


### PR DESCRIPTION
被坑了，直接取返回值以为是media_id，其实是个集合对象。建议在文档里面也详细描述一下返回值。