### PR TITLE
修复Https 请求判断不准

### DIFF
--- a/src/Support/Url.php
+++ b/src/Support/Url.php
@@ -37,9 +37,9 @@ class Url
             return 'http://localhost';
         }
 
-        $protocol = (!empty($_SERVER['HTTPS'])
-                        && $_SERVER['HTTPS'] !== 'off'
-                        || (int) $_SERVER['SERVER_PORT'] === 443) ? 'https://' : 'http://';
+        $protocol = (isset($_SERVER['HTTPS']) && (strcasecmp($_SERVER['HTTPS'], 'on') === 0 || $_SERVER['HTTPS'] == 1)
+            || isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && strcasecmp($_SERVER['HTTP_X_FORWARDED_PROTO'], 'https') === 0)
+            ? 'https://' : 'http://';
 
         return $protocol.$_SERVER['HTTP_HOST'].$_SERVER['REQUEST_URI'];
     }


### PR DESCRIPTION
当服务器在负载均衡后端时，单纯的使用`$_SERVER['HTTPS']`来判断是不准的，因为负载均衡前端走Https,后端走Http的情况下，判断会出错。