### PR TITLE
Fix mini-program qrcode.

### DIFF
--- a/src/MiniProgram/QRCode/QRCode.php
+++ b/src/MiniProgram/QRCode/QRCode.php
@@ -30,21 +30,77 @@ use EasyWeChat\MiniProgram\Core\AbstractMiniProgram;
 
 class QRCode extends AbstractMiniProgram
 {
-    /**
-     * API.
-     */
+    const API_GET_WXACODE = 'https://api.weixin.qq.com/wxa/getwxacode';
+    const API_GET_WXACODE_UNLIMIT = 'http://api.weixin.qq.com/wxa/getwxacodeunlimit';
     const API_CREATE_QRCODE = 'https://api.weixin.qq.com/cgi-bin/wxaapp/createwxaqrcode';
 
     /**
-     * Create mini program qrcode.
+     * Get WXACode.
      *
-     * @param $path
-     * @param int $width
+     * @param string $path
+     * @param int    $width
+     * @param bool   $autoColor
+     * @param array  $lineColor
      *
-     * @return \EasyWeChat\Support\Collection
+     * @return \Psr\Http\Message\StreamInterface
      */
-    public function create($path, $width = 430)
+    public function getWXACode($path, $width = 430, $autoColor = false, $lineColor = ['r' => 0, 'g' => 0, 'b' => 0])
     {
-        return $this->parseJSON('JSON', [self::API_CREATE_QRCODE, compact('path', 'width')]);
+        $params = [
+            'path' => $path,
+            'width' => $width,
+            'auto_color' => $autoColor,
+            'line_color' => $lineColor,
+        ];
+
+        return $this->getStream(self::API_GET_WXACODE, $params);
+    }
+
+    /**
+     * Get WXACode unlimit.
+     *
+     * @param string $scene
+     * @param int    $width
+     * @param bool   $autoColor
+     * @param array  $lineColor
+     *
+     * @return \Psr\Http\Message\StreamInterface
+     */
+    public function getWXACodeUnlimit($scene, $width = 430, $autoColor = false, $lineColor = ['r' => 0, 'g' => 0, 'b' => 0])
+    {
+        $params = [
+            'scene' => $scene,
+            'width' => $width,
+            'auto_color' => $autoColor,
+            'line_color' => $lineColor,
+        ];
+
+        return $this->getStream(self::API_GET_WXACODE_UNLIMIT, $params);
+    }
+
+    /**
+     * Create QRCode.
+     *
+     * @param string $path
+     * @param int    $width
+     *
+     * @return \Psr\Http\Message\StreamInterface
+     */
+    public function createQRCode($path, $width = 430)
+    {
+        return $this->getStream(self::API_CREATE_QRCODE, compact('path', 'width'));
+    }
+
+    /**
+     * Get stream.
+     *
+     * @param string $endpoint
+     * @param array  $params
+     *
+     * @return \Psr\Http\Message\StreamInterface
+     */
+    protected function getStream($endpoint, $params)
+    {
+        return $this->getHttp()->json($endpoint, $params)->getBody();
     }
 }


### PR DESCRIPTION
Fix #766
返回二进制流内容

Example:
```php
$content = $miniProgram->qrcode->getWXACode('path/to/page');
file_put_contents('/foo/bar.jpg', $content);
```