### PR TITLE
临时二维码也是支持scene_str的，这里补充上

### DIFF
--- a/src/QRCode/QRCode.php
+++ b/src/QRCode/QRCode.php
@@ -30,8 +30,10 @@ class QRCode extends AbstractAPI
 {
     const DAY = 86400;
     const SCENE_MAX_VALUE = 100000;
+    const SCENE_TEMPORARY_MAX_VALUE = 1 << 32;
     const SCENE_QR_CARD = 'QR_CARD';
     const SCENE_QR_TEMPORARY = 'QR_SCENE';
+    const SCENE_QR_TEMPORARY_STR = 'QR_STR_SCENE';
     const SCENE_QR_FOREVER = 'QR_LIMIT_SCENE';
     const SCENE_QR_FOREVER_STR = 'QR_LIMIT_STR_SCENE';
 
@@ -63,16 +65,24 @@ class QRCode extends AbstractAPI
     /**
      * Create temporary.
      *
-     * @param string $sceneId
+     * @param string $sceneValue
      * @param null   $expireSeconds
      *
      * @return \EasyWeChat\Support\Collection
      */
-    public function temporary($sceneId, $expireSeconds = null)
+    public function temporary($sceneValue, $expireSeconds = null)
     {
-        $scene = ['scene_id' => intval($sceneId)];
+        if (is_int($sceneValue) && $sceneValue > 0 && $sceneValue < self::SCENE_TEMPORARY_MAX_VALUE) {
+            $type = self::SCENE_QR_TEMPORARY;
+            $sceneKey = 'scene_id';
+        } else {
+            $type = self::SCENE_QR_TEMPORARY_STR;
+            $sceneKey = 'scene_str';
+        }
 
-        return $this->create(self::SCENE_QR_TEMPORARY, $scene, true, $expireSeconds);
+        $scene = [$sceneKey => $sceneValue];
+
+        return $this->create($type, $scene, true, $expireSeconds);
     }
 
     /**


### PR DESCRIPTION
请参阅微信公众号官方文档：
https://mp.weixin.qq.com/wiki?t=resource/res_main&id=mp1443433542

见以下文段：

或者也可以使用以下POST数据创建字符串形式的二维码参数：
{"expire_seconds": 604800, "action_name": "QR_STR_SCENE", "action_info": {"scene": {"scene_str": "test"}}}