### PR TITLE
[3.1] Payment/API 没有使用全局的 cache

### DIFF
--- a/src/Foundation/ServiceProviders/PaymentServiceProvider.php
+++ b/src/Foundation/ServiceProviders/PaymentServiceProvider.php
@@ -59,7 +59,7 @@ class PaymentServiceProvider implements ServiceProviderInterface
         };
 
         $pimple['payment'] = function ($pimple) {
-            $payment = new Payment($pimple['merchant']);
+            $payment = new Payment($pimple['merchant'], $pimple['cache']);
             $payment->sandboxMode(
                 (bool) $pimple['config']->get('payment.sandbox_mode')
             );

--- a/src/Payment/API.php
+++ b/src/Payment/API.php
@@ -58,7 +58,7 @@ class API extends AbstractAPI
     /**
      * Cache.
      *
-     * @var Cache
+     * @var \Doctrine\Common\Cache\Cache
      */
     protected $cache;
 

--- a/src/Payment/API.php
+++ b/src/Payment/API.php
@@ -94,8 +94,8 @@ class API extends AbstractAPI
     /**
      * API constructor.
      *
-     * @param \EasyWeChat\Payment\Merchant   $merchant
-     * @param \EasyWeChat\Payment\Cache|null $cache
+     * @param \EasyWeChat\Payment\Merchant      $merchant
+     * @param \Doctrine\Common\Cache\Cache|null $cache
      */
     public function __construct(Merchant $merchant, Cache $cache = null)
     {

--- a/src/Payment/Payment.php
+++ b/src/Payment/Payment.php
@@ -21,6 +21,7 @@
 
 namespace EasyWeChat\Payment;
 
+use Doctrine\Common\Cache\Cache;
 use EasyWeChat\Core\Exceptions\FaultException;
 use EasyWeChat\Support\Url as UrlHelper;
 use EasyWeChat\Support\XML;
@@ -52,13 +53,22 @@ class Payment
     protected $merchant;
 
     /**
+     * Cache.
+     *
+     * @var Cache
+     */
+    protected $cache;
+
+    /**
      * Constructor.
      *
-     * @param Merchant $merchant
+     * @param \EasyWeChat\Payment\Merchant      $merchant
+     * @param \Doctrine\Common\Cache\Cache|null $cache
      */
-    public function __construct(Merchant $merchant)
+    public function __construct(Merchant $merchant, Cache $cache = null)
     {
         $this->merchant = $merchant;
+        $this->cache = $cache;
     }
 
     /**
@@ -318,7 +328,7 @@ class Payment
      */
     public function getAPI()
     {
-        return $this->api ?: $this->api = new API($this->getMerchant());
+        return $this->api ?: $this->api = new API($this->getMerchant(), $this->cache);
     }
 
     /**

--- a/src/Payment/Payment.php
+++ b/src/Payment/Payment.php
@@ -55,7 +55,7 @@ class Payment
     /**
      * Cache.
      *
-     * @var Cache
+     * @var \Doctrine\Common\Cache\Cache
      */
     protected $cache;
 


### PR DESCRIPTION
在`$options`里设置了自定义 cache，但 Payment/API 总是默认使用 `FilesystemCache`：

```php
use EasyWeChat\Foundation\Application;
use Example\MyCustomCache;

$cache = new MyCustomCache();

$options = [
    'app_id' => 'xxxx',
    'cache' => $cache
    // ...
    // payment
    'payment' => [
        'merchant_id'        => 'your-mch-id',
        // ...
    ],
];
$app = new Application($options);
```

需要在创建 Payment/API 时，传入 cache 参数。
