### PR TITLE
增加OAuth中Guzzle\Client的配置项的设置

### DIFF
--- a/src/Foundation/ServiceProviders/OAuthServiceProvider.php
+++ b/src/Foundation/ServiceProviders/OAuthServiceProvider.php
@@ -44,15 +44,17 @@ class OAuthServiceProvider implements ServiceProviderInterface
         $pimple['oauth'] = function ($pimple) {
             $callback = $this->prepareCallbackUrl($pimple);
             $scopes = $pimple['config']->get('oauth.scopes', []);
-            $socialite = (new Socialite(
-                [
-                    'wechat' => [
-                        'client_id' => $pimple['config']['app_id'],
-                        'client_secret' => $pimple['config']['secret'],
-                        'redirect' => $callback,
-                    ],
-                ]
-            ))->driver('wechat');
+            $config = [
+                'wechat' => [
+                    'client_id' => $pimple['config']['app_id'],
+                    'client_secret' => $pimple['config']['secret'],
+                    'redirect' => $callback,
+                ],
+            ];
+            if (in_array('guzzle', $pimple['config'])){
+                $config['guzzle'] = $pimple['config']['guzzle'];
+            }
+            $socialite = (new Socialite($config))->driver('wechat');
 
             if (!empty($scopes)) {
                 $socialite->scopes($scopes);

--- a/src/Foundation/ServiceProviders/OpenPlatformServiceProvider.php
+++ b/src/Foundation/ServiceProviders/OpenPlatformServiceProvider.php
@@ -149,13 +149,17 @@ class OpenPlatformServiceProvider implements ServiceProviderInterface
         $pimple['open_platform.oauth'] = function ($pimple) {
             $callback = $this->prepareCallbackUrl($pimple);
             $scopes = $pimple['config']->get('open_platform.oauth.scopes', []);
-            $socialite = (new Socialite([
+            $config = [
                 'wechat_open' => [
                     'client_id' => $pimple['open_platform.authorizer']->getAppId(),
                     'client_secret' => $pimple['open_platform.access_token'],
                     'redirect' => $callback,
                 ],
-            ]))->driver('wechat_open');
+            ];
+            if (in_array('guzzle', $pimple['config'])){
+                $config['guzzle'] = $pimple['config']['guzzle'];
+            }
+            $socialite = (new Socialite($config))->driver('wechat_open');
 
             if (!empty($scopes)) {
                 $socialite->scopes($scopes);


### PR DESCRIPTION

让`socialite`支持设置`Guzzle\Client `的属性，结合EasyWechat中的配置项

