### PR TITLE
[4.0] Pass proper arguments to the Response constructor

### DIFF
--- a/src/Payment/Traits/HandleNotify.php
+++ b/src/Payment/Traits/HandleNotify.php
@@ -57,7 +57,7 @@ trait HandleNotify
             ];
         }
 
-        return new Response(Support\XML::build($response));
+        return new Response(200, [], Support\XML::build($response));
     }
 
     /**


### PR DESCRIPTION
`\GuzzleHttp\Psr7\Response::__construct` 的签名: 

```php
    /**
     * @param int                                  $status  Status code
     * @param array                                $headers Response headers
     * @param string|null|resource|StreamInterface $body    Response body
     * @param string                               $version Protocol version
     * @param string|null                          $reason  Reason phrase (when empty a default will be used based on the status code)
     */
    public function __construct(
        $status = 200,
        array $headers = [],
        $body = null,
        $version = '1.1',
        $reason = null
    ) {
```
`body` 为第三个参数