### PR TITLE
修改acess_token无效时微信返回错误码的判断

### DIFF
--- a/src/Core/AbstractAPI.php
+++ b/src/Core/AbstractAPI.php
@@ -215,7 +215,7 @@ abstract class AbstractAPI
             // Limit the number of retries to 2
             if ($retries <= self::$maxRetries && $response && $body = $response->getBody()) {
                 // Retry on server errors
-                if (stripos($body, 'errcode') && (stripos($body, '40001') || stripos($body, '42001'))) {
+                if (stripos($body, 'errcode') !== false && (stripos($body, '40001') !== false || stripos($body, '42001') !== false )) {
                     $field = $this->accessToken->getQueryName();
                     $token = $this->accessToken->getToken(true);
 


### PR DESCRIPTION
stripos的返回值不能直接判断“true”，“false”
Fixes #915