### PR TITLE
修改通过ticket换取二维码图片地址的逻辑

### DIFF
--- a/src/BasicService/QrCode/Client.php
+++ b/src/BasicService/QrCode/Client.php
@@ -78,6 +78,7 @@ class Client extends BaseClient
 
     /**
      * Return url for ticket.
+     * Detail: https://mp.weixin.qq.com/wiki?t=resource/res_main&id=mp1443433542
      *
      * @param string $ticket
      *
@@ -85,7 +86,7 @@ class Client extends BaseClient
      */
     public function url($ticket)
     {
-        return sprintf($this->baseUri.'showqrcode?ticket=%s', $ticket);
+        return sprintf('https://mp.weixin.qq.com/cgi-bin/showqrcode?ticket=%s', urlencode($ticket));
     }
 
     /**

--- a/src/BasicService/QrCode/Client.php
+++ b/src/BasicService/QrCode/Client.php
@@ -78,7 +78,7 @@ class Client extends BaseClient
 
     /**
      * Return url for ticket.
-     * Detail: https://mp.weixin.qq.com/wiki?t=resource/res_main&id=mp1443433542
+     * Detail: https://mp.weixin.qq.com/wiki?t=resource/res_main&id=mp1443433542 .
      *
      * @param string $ticket
      *

--- a/tests/BasicService/QrCode/ClientTest.php
+++ b/tests/BasicService/QrCode/ClientTest.php
@@ -53,7 +53,7 @@ class ClientTest extends TestCase
     public function testUrl()
     {
         $client = $this->mockApiClient(Client::class, 'create');
-        $this->assertSame(sprintf('https://api.weixin.qq.com/cgi-bin/showqrcode?ticket=%s', 'ticket'), $client->url('ticket'));
+        $this->assertSame(sprintf('https://mp.weixin.qq.com/cgi-bin/showqrcode?ticket=%s', 'ticket%3F%2F'), $client->url('ticket?/'));
     }
 
     public function testCreate()


### PR DESCRIPTION
获取二维码图片 url 的接口 url 有误

具体： https://mp.weixin.qq.com/wiki?t=resource/res_main&id=mp1443433542
