### PR TITLE
修复微信收款（个人转账版）商户添加、查询含有多余字段导致签名失败的问题

### DIFF
--- a/src/Payment/Merchant/Client.php
+++ b/src/Payment/Merchant/Client.php
@@ -72,6 +72,12 @@ class Client extends BaseClient
      */
     protected function manage(array $params, array $query)
     {
+        $params = array_merge($params, [
+            'nonce_str' => '',
+            'sub_mch_id' => '',
+            'sub_appid' => ''
+        ]);
+
         return $this->safeRequest('secapi/mch/submchmanage', $params, 'post', compact('query'));
     }
 }


### PR DESCRIPTION
覆盖无效字段