### PR TITLE
Implement server guard observers.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ php:
   - 7.1
 
 before_script:
+  - export TZ=Asia/Shanghai
   - composer self-update
   - composer install --prefer-source --no-interaction --dev
   - ./vendor/bin/phplint

--- a/src/Kernel/ServerGuard.php
+++ b/src/Kernel/ServerGuard.php
@@ -78,7 +78,7 @@ class ServerGuard
 
         foreach ($app->config->get('observers', []) as $observer) {
             if (is_array($observer) && !is_callable($observer)) {
-                [$observer, $condition] = $observer;
+                list($observer, $condition) = $observer;
             }
 
             $this->push($observer, $condition ?? '*');

--- a/src/Kernel/ServerGuard.php
+++ b/src/Kernel/ServerGuard.php
@@ -75,6 +75,14 @@ class ServerGuard
     public function __construct(ServiceContainer $app)
     {
         $this->app = $app;
+
+        foreach ($app->config->get('observers', []) as $observer) {
+            if (is_array($observer) && !is_callable($observer)) {
+                [$observer, $condition] = $observer;
+            }
+
+            $this->push($observer, $condition ?? '*');
+        }
     }
 
     /**


### PR DESCRIPTION
Related: #719

Examples:

```php
use EasyWeChat\Kernel\Messages\Message;

$options = [
    // ...
    'observers' => [
        new CustomHandler(),
        // with condition
        [new CustomHandler(), Message::IMAGE],
        // closure
        function ($payload) {
            return 'Hello world!';
        },
    ],
];

echo Factory::officialAccount($options)->server->serve();
```