### PR TITLE
查询企业付款接口参数调整，加入企业付款到银行卡接口（RSA 参数加密待完成）

### DIFF
--- a/src/Payment/Transfer/Client.php
+++ b/src/Payment/Transfer/Client.php
@@ -21,30 +21,31 @@ use EasyWeChat\Payment\Kernel\BaseClient;
 class Client extends BaseClient
 {
     /**
-     * Query MerchantPay.
+     * Query MerchantPay to balance.
      *
-     * @param array $params
+     * @param string $partnetTradeNo
      *
      * @return \Psr\Http\Message\ResponseInterface|\EasyWeChat\Kernel\Support\Collection|array|object|string
      */
-    public function info(array $params)
+    public function queryBalanceOrder(string $partnetTradeNo)
     {
-        $base = [
+        $params = [
             'appid' => $this->app['config']->app_id,
             'mch_id' => $this->app['config']->mch_id,
+            'partner_trade_no' => $partnetTradeNo,
         ];
 
-        return $this->safeRequest('mmpaymkttransfers/gettransferinfo', array_merge($base, $params));
+        return $this->safeRequest('mmpaymkttransfers/gettransferinfo', $params);
     }
 
     /**
-     * Send MerchantPay.
+     * Send MerchantPay to balance.
      *
      * @param array $params
      *
      * @return \Psr\Http\Message\ResponseInterface|\EasyWeChat\Kernel\Support\Collection|array|object|string
      */
-    public function send(array $params)
+    public function toBalance(array $params)
     {
         $base = [
             'mchid' => $this->app['config']->mch_id,
@@ -52,5 +53,40 @@ class Client extends BaseClient
         ];
 
         return $this->safeRequest('mmpaymkttransfers/promotion/transfers', array_merge($base, $params));
+    }
+
+    /**
+     * Query MerchantPay order to BankCard.
+     *
+     * @param string $partnetTradeNo
+     *
+     * @return \Psr\Http\Message\ResponseInterface|\EasyWeChat\Kernel\Support\Collection|array|object|string
+     */
+    public function queryBankCardOrder(string $partnetTradeNo)
+    {
+        $params = [
+            'mch_id' => $this->app['config']->mch_id,
+            'partner_trade_no' => $partnetTradeNo,
+        ];
+
+        return $this->safeRequest('mmpaysptrans/query_bank', $params);
+    }
+
+    /**
+     * Send MerchantPay to BankCard.
+     *
+     * @param array $params
+     *
+     * @return \Psr\Http\Message\ResponseInterface|\EasyWeChat\Kernel\Support\Collection|array|object|string
+     */
+    public function toBankCard(array $params)
+    {
+        $base = [
+            'mchid' => $this->app['config']->mch_id,
+        ];
+
+        // TODO: RSA 加密 enc_bank_no, enc_true_name
+
+        return $this->safeRequest('mmpaysptrans/pay_bank', array_merge($base, $params));
     }
 }

--- a/tests/Payment/Transfer/ClientTest.php
+++ b/tests/Payment/Transfer/ClientTest.php
@@ -33,13 +33,13 @@ class ClientTest extends TestCase
         ], $config));
     }
 
-    public function testInfo()
+    public function testQueryBalanceOrder()
     {
         $app = $this->makeApp();
 
         $client = $this->mockApiClient(Client::class, ['safeRequest'], $app)->makePartial();
 
-        $params = ['partner_trade_no' => 'bar'];
+        $partnerTradeNo = 'bar';
 
         $client->expects()->safeRequest('mmpaymkttransfers/gettransferinfo', \Mockery::on(function ($paramsForSafeRequest) use ($app) {
             $this->assertSame($paramsForSafeRequest['partner_trade_no'], 'bar');
@@ -49,10 +49,10 @@ class ClientTest extends TestCase
             return true;
         }))->andReturn('mock-result');
 
-        $this->assertSame('mock-result', $client->info($params));
+        $this->assertSame('mock-result', $client->queryBalanceOrder($partnerTradeNo));
     }
 
-    public function testSend()
+    public function testToBalance()
     {
         $app = $this->makeApp();
 
@@ -70,6 +70,44 @@ class ClientTest extends TestCase
             return true;
         }))->andReturn('mock-result');
 
-        $this->assertSame('mock-result', $client->send($params));
+        $this->assertSame('mock-result', $client->toBalance($params));
+    }
+
+    public function testQueryBankCardOrder()
+    {
+        $app = $this->makeApp();
+
+        $client = $this->mockApiClient(Client::class, ['safeRequest'], $app)->makePartial();
+
+        $partnerTradeNo = 'bar';
+
+        $client->expects()->safeRequest('mmpaysptrans/query_bank', \Mockery::on(function ($paramsForSafeRequest) use ($app) {
+            $this->assertSame($paramsForSafeRequest['partner_trade_no'], 'bar');
+            $this->assertSame($paramsForSafeRequest['mch_id'], $app['config']->mch_id);
+
+            return true;
+        }))->andReturn('mock-result');
+
+        $this->assertSame('mock-result', $client->queryBankCardOrder($partnerTradeNo));
+    }
+
+    public function testToBackCard()
+    {
+        $app = $this->makeApp();
+
+        $client = $this->mockApiClient(Client::class, ['send', 'safeRequest'], $app)->makePartial();
+
+        $params = [
+            'foo' => 'bar',
+        ];
+
+        $client->expects()->safeRequest('mmpaysptrans/pay_bank', \Mockery::on(function ($paramsForSafeRequest) use ($params, $app) {
+            $this->assertSame($params['foo'], $paramsForSafeRequest['foo']);
+            $this->assertSame($paramsForSafeRequest['mchid'], $app['config']->mch_id);
+
+            return true;
+        }))->andReturn('mock-result');
+
+        $this->assertSame('mock-result', $client->toBankCard($params));
     }
 }


### PR DESCRIPTION
- 企业付款到零钱及查询接口方法重命名
- 初步加入企业付款到银行卡的接口，**但部分参数需要 RSA 加密的问题待解决**
- 企业付款查询接口，参数由 array 类型调整为直接传入 string 型商户订单号
- 调整相关单元测试