### PR TITLE
🚧 Auto discover extensions.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "symfony/http-foundation": "2.*|^3.0",
         "symfony/psr-http-message-bridge": "~0.3|^1.0",
         "symfony/cache": "^3.1|^3.3",
-        "easywechat-composer/easywechat-composer": "^1.0"
+        "easywechat-composer/easywechat-composer": "^0.1"
     },
     "require-dev": {
         "phpunit/phpunit": "~6.0",

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
         "guzzlehttp/guzzle": "^6.2",
         "symfony/http-foundation": "2.*|^3.0",
         "symfony/psr-http-message-bridge": "~0.3|^1.0",
-        "symfony/cache": "^3.1|^3.3"
+        "symfony/cache": "^3.1|^3.3",
+        "easywechat-composer/easywechat-composer": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~6.0",

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "symfony/http-foundation": "2.*|^3.0",
         "symfony/psr-http-message-bridge": "~0.3|^1.0",
         "symfony/cache": "^3.1|^3.3",
-        "easywechat-composer/easywechat-composer": "^0.1"
+        "easywechat-composer/easywechat-composer": "^0.1",
         "psr/simple-cache": "^1.0"
     },
     "require-dev": {

--- a/src/Kernel/ServerGuard.php
+++ b/src/Kernel/ServerGuard.php
@@ -89,7 +89,7 @@ class ServerGuard
     {
         foreach ($packages as $package) {
             foreach ($package['observers'] ?? [] as $handler) {
-                if (class_exists($handler) && in_array(EventHandlerInterface::class, class_implements($handler))) {
+                if (class_exists($handler) && in_array(EventHandlerInterface::class, class_implements($handler), true)) {
                     $this->push($handler);
                 }
             }

--- a/src/Kernel/ServerGuard.php
+++ b/src/Kernel/ServerGuard.php
@@ -11,6 +11,7 @@
 
 namespace EasyWeChat\Kernel;
 
+use EasyWeChat\Kernel\Contracts\EventHandlerInterface;
 use EasyWeChat\Kernel\Contracts\MessageInterface;
 use EasyWeChat\Kernel\Exceptions\BadRequestException;
 use EasyWeChat\Kernel\Exceptions\InvalidArgumentException;
@@ -75,6 +76,24 @@ class ServerGuard
     public function __construct(ServiceContainer $app)
     {
         $this->app = $app;
+
+        if (file_exists($packages = __DIR__.'/../../extensions/packages.php')) {
+            $this->discoverPackages(require $packages);
+        }
+    }
+
+    /**
+     * @param array $packages
+     */
+    protected function discoverPackages(array $packages)
+    {
+        foreach ($packages as $package) {
+            foreach ($package['observers'] ?? [] as $handler) {
+                if (class_exists($handler) && in_array(EventHandlerInterface::class, class_implements($handler))) {
+                    $this->push($handler);
+                }
+            }
+        }
     }
 
     /**

--- a/src/Kernel/ServerGuard.php
+++ b/src/Kernel/ServerGuard.php
@@ -11,7 +11,6 @@
 
 namespace EasyWeChat\Kernel;
 
-use EasyWeChat\Kernel\Contracts\EventHandlerInterface;
 use EasyWeChat\Kernel\Contracts\MessageInterface;
 use EasyWeChat\Kernel\Exceptions\BadRequestException;
 use EasyWeChat\Kernel\Exceptions\InvalidArgumentException;
@@ -77,22 +76,8 @@ class ServerGuard
     {
         $this->app = $app;
 
-        if (file_exists($packages = __DIR__.'/../../extensions/packages.php')) {
-            $this->discoverPackages(require $packages);
-        }
-    }
-
-    /**
-     * @param array $packages
-     */
-    protected function discoverPackages(array $packages)
-    {
-        foreach ($packages as $package) {
-            foreach ($package['observers'] ?? [] as $handler) {
-                if (class_exists($handler) && in_array(EventHandlerInterface::class, class_implements($handler), true)) {
-                    $this->push($handler);
-                }
-            }
+        foreach ($this->app->extension->observers() as $observer) {
+            call_user_func_array([$this, 'push'], $observer);
         }
     }
 

--- a/src/Kernel/ServiceContainer.php
+++ b/src/Kernel/ServiceContainer.php
@@ -11,6 +11,7 @@
 
 namespace EasyWeChat\Kernel;
 
+use EasyWeChatComposer\Extension;
 use GuzzleHttp\Client;
 use Monolog\Handler\ErrorLogHandler;
 use Monolog\Handler\HandlerInterface;
@@ -122,6 +123,10 @@ class ServiceContainer extends Container
         foreach ($this->providers as $provider) {
             $this->register(new $provider());
         }
+
+        $this['extension'] = function ($app) {
+            return new Extension($app);
+        };
 
         return $this;
     }


### PR DESCRIPTION
满足以下条件的 composer 包即可自动注入 observer，EasyWeChat 无需另外配置

相关包: [easywechat-composer/easywechat-composer](https://github.com/mingyoung/easywechat-composer)
示例包：[open-platform-testcase](https://github.com/mingyoung/open-platform-testcase)

---

`composer.json` 内容：
> type 需指定为 easywechat-extension
```json
{
    "name": "foo/bar",
    "type": "easywechat-extension",
    "autoload": {
        "psr-4": {
            "Acme\\": ""
        }
    },
    "extra": {
        "observers": [
            "Acme\\ExampleHandler",
            "Acme\\OtherHandler"
        ]
    }
}
```

一个完整的 `ExampleHandler` 如下：
```php
<?php

namespace Acme;

use EasyWeChat\Kernel\Contracts\EventHandlerInterface;
use EasyWeChat\OfficialAccount\Application as OfficialAccount;
use EasyWeChat\MiniProgram\Application as MiniProgram;
use EasyWeChat\Kernel\Messages\Message;

class ExampleHandler implements EventHandlerInterface
{
    public function handle(array $payload = [])
    {
        return 'hello world!';
    }

    // 指定注入的应用（可选）
    public static function getAccessor()
    {
        return OfficialAccount::class;
        // 或多个应用
        // return [OfficialAccount::class, MiniProgram::class,];
    }

    // 注入条件（可选）
    public static function onCondition()
    {
        return Message::IMAGE;
        // or 
        // return Message::IMAGE | Message::LOCATION;
    }
}
```

禁用某个 observer

```php
EasyWeChat::officialAccount(
    // 配置加入以下内容：
    'disable_observers' => [
        '*', // 传入 * 则禁用所有
        'Acme\\ExampleHandler',
    ],
);
```
