### PR TITLE
修復微信支付沙盒模式的通知結果本地校驗失敗錯誤。

### DIFF
--- a/src/Payment/API.php
+++ b/src/Payment/API.php
@@ -465,7 +465,7 @@ class API extends AbstractAPI
      *
      * @return string
      */
-    protected function getSignkey($api)
+    public function getSignkey($api)
     {
         return $this->sandboxEnabled && self::API_SANDBOX_SIGN_KEY !== $api ? $this->getSandboxSignKey() : $this->merchant->key;
     }

--- a/src/Payment/Notify.php
+++ b/src/Payment/Notify.php
@@ -69,9 +69,9 @@ class Notify
      *
      * @return bool
      */
-    public function isValid()
+    public function isValid($signkey)
     {
-        $localSign = generate_sign($this->getNotify()->except('sign')->all(), $this->merchant->key, 'md5');
+        $localSign = generate_sign($this->getNotify()->except('sign')->all(), $signkey, 'md5');
 
         return $localSign === $this->getNotify()->get('sign');
     }

--- a/src/Payment/Payment.php
+++ b/src/Payment/Payment.php
@@ -103,7 +103,7 @@ class Payment
     public function handleNotify(callable $callback)
     {
         $notify = $this->getNotify();
-        $signkey = $this->getAPI()->getSignkey(NULL);
+        $signkey = $this->getAPI()->getSignkey(null);
         if (!$notify->isValid($signkey)) {
             throw new FaultException('Invalid request payloads.', 400);
         }
@@ -169,7 +169,7 @@ class Payment
     public function handleScanNotify(callable $callback)
     {
         $notify = $this->getNotify();
-        $signkey = $this->getAPI()->getSignkey(NULL);
+        $signkey = $this->getAPI()->getSignkey(null);
         if (!$notify->isValid($signkey)) {
             throw new FaultException('Invalid request payloads.', 400);
         }

--- a/src/Payment/Payment.php
+++ b/src/Payment/Payment.php
@@ -103,7 +103,7 @@ class Payment
     public function handleNotify(callable $callback)
     {
         $notify = $this->getNotify();
-        $signkey = $this->getKey();
+        $signkey = $this->getAPI()->getSignkey(NULL);
         if (!$notify->isValid($signkey)) {
             throw new FaultException('Invalid request payloads.', 400);
         }
@@ -169,7 +169,7 @@ class Payment
     public function handleScanNotify(callable $callback)
     {
         $notify = $this->getNotify();
-        $signkey = $this->getKey();
+        $signkey = $this->getAPI()->getSignkey(NULL);
         if (!$notify->isValid($signkey)) {
             throw new FaultException('Invalid request payloads.', 400);
         }
@@ -385,15 +385,5 @@ class Payment
         if (is_callable([$this->getAPI(), $method])) {
             return call_user_func_array([$this->api, $method], $args);
         }
-    }
-
-    /**
-     * Get merchant key or merchant wechat sandbox key for live/sandbox modal.
-     *
-     * @return string
-     */
-    public function getKey()
-    {
-        return $this->__call('getSignkey', [null]);
     }
 }

--- a/src/Payment/Payment.php
+++ b/src/Payment/Payment.php
@@ -103,8 +103,8 @@ class Payment
     public function handleNotify(callable $callback)
     {
         $notify = $this->getNotify();
-
-        if (!$notify->isValid()) {
+        $signkey = $this->getKey();
+        if (!$notify->isValid($signkey)) {
             throw new FaultException('Invalid request payloads.', 400);
         }
 
@@ -169,8 +169,8 @@ class Payment
     public function handleScanNotify(callable $callback)
     {
         $notify = $this->getNotify();
-
-        if (!$notify->isValid()) {
+        $signkey = $this->getKey();
+        if (!$notify->isValid($signkey)) {
             throw new FaultException('Invalid request payloads.', 400);
         }
 
@@ -385,5 +385,15 @@ class Payment
         if (is_callable([$this->getAPI(), $method])) {
             return call_user_func_array([$this->api, $method], $args);
         }
+    }
+
+    /**
+     * Get merchant key or merchant wechat sandbox key for live/sandbox modal.
+     *
+     * @return string
+     */
+    public function getKey()
+    {
+        return $this->__call('getSignkey', [null]);
     }
 }

--- a/tests/Payment/PaymentNotifyTest.php
+++ b/tests/Payment/PaymentNotifyTest.php
@@ -36,11 +36,11 @@ class PaymentNotifyTest extends TestCase
 
         $notify = new Notify(new Merchant(['key' => 'sign_key']), $request);
 
-        $this->assertTrue($notify->isValid());
+        $this->assertTrue($notify->isValid('sign_key'));
 
         $notify = new Notify(new Merchant(['key' => 'different_sign_key']), $request);
 
-        $this->assertFalse($notify->isValid());
+        $this->assertFalse($notify->isValid('different_sign_key'));
     }
 
     /**

--- a/tests/Payment/PaymentPaymentTest.php
+++ b/tests/Payment/PaymentPaymentTest.php
@@ -66,10 +66,9 @@ class PaymentPaymentTest extends TestCase
     public function testHandleNotifyWithInvalidRequest()
     {
         $merchant = new Merchant(['key' => 'different_sign_key']);
-        $payment = \Mockery::mock(Payment::class.'[getNotify, getKey]', [$merchant]);
+        $payment = \Mockery::mock(Payment::class.'[getNotify]', [$merchant]);
         $request = Request::create('/callback', 'POST', [], [], [], [], '<xml><foo>bar</foo></xml>');
         $notify = \Mockery::mock(Notify::class.'[isValid]', [$merchant, $request]);
-        $payment->shouldReceive('getKey')->andReturn('different_sign_key');
         $notify->shouldReceive('isValid')->andReturn(false);
         $payment->shouldReceive('getNotify')->andReturn($notify);
 
@@ -85,10 +84,9 @@ class PaymentPaymentTest extends TestCase
     public function testHandleNotify()
     {
         $merchant = new Merchant(['key' => 'different_sign_key']);
-        $payment = \Mockery::mock(Payment::class.'[getNotify, getKey]', [$merchant]);
+        $payment = \Mockery::mock(Payment::class.'[getNotify]', [$merchant]);
         $request = Request::create('/callback', 'POST', [], [], [], [], '<xml><foo>bar</foo></xml>');
         $notify = \Mockery::mock(Notify::class.'[isValid]', [$merchant, $request]);
-        $payment->shouldReceive('getKey')->andReturn('different_sign_key');
         $notify->shouldReceive('isValid')->andReturn(true);
         $payment->shouldReceive('getNotify')->andReturn($notify);
 

--- a/tests/Payment/PaymentPaymentTest.php
+++ b/tests/Payment/PaymentPaymentTest.php
@@ -66,9 +66,10 @@ class PaymentPaymentTest extends TestCase
     public function testHandleNotifyWithInvalidRequest()
     {
         $merchant = new Merchant(['key' => 'different_sign_key']);
-        $payment = \Mockery::mock(Payment::class.'[getNotify]', [$merchant]);
+        $payment = \Mockery::mock(Payment::class.'[getNotify, getKey]', [$merchant]);
         $request = Request::create('/callback', 'POST', [], [], [], [], '<xml><foo>bar</foo></xml>');
         $notify = \Mockery::mock(Notify::class.'[isValid]', [$merchant, $request]);
+        $payment->shouldReceive('getKey')->andReturn('different_sign_key');
         $notify->shouldReceive('isValid')->andReturn(false);
         $payment->shouldReceive('getNotify')->andReturn($notify);
 
@@ -84,9 +85,10 @@ class PaymentPaymentTest extends TestCase
     public function testHandleNotify()
     {
         $merchant = new Merchant(['key' => 'different_sign_key']);
-        $payment = \Mockery::mock(Payment::class.'[getNotify]', [$merchant]);
+        $payment = \Mockery::mock(Payment::class.'[getNotify, getKey]', [$merchant]);
         $request = Request::create('/callback', 'POST', [], [], [], [], '<xml><foo>bar</foo></xml>');
         $notify = \Mockery::mock(Notify::class.'[isValid]', [$merchant, $request]);
+        $payment->shouldReceive('getKey')->andReturn('different_sign_key');
         $notify->shouldReceive('isValid')->andReturn(true);
         $payment->shouldReceive('getNotify')->andReturn($notify);
 
@@ -125,9 +127,10 @@ class PaymentPaymentTest extends TestCase
     public function testHandleScanNotify()
     {
         $merchant = new Merchant(['key' => 'different_sign_key']);
-        $payment = \Mockery::mock(Payment::class.'[getNotify]', [$merchant]);
+        $payment = \Mockery::mock(Payment::class.'[getNotify, getKey]', [$merchant]);
         $request = Request::create('/callback', 'POST', [], [], [], [], '<xml><product_id>88888</product_id><openid>o8GeHuLAsgefS_80exEr1cTqekUs</openid></xml>');
         $notify = \Mockery::mock(Notify::class.'[isValid]', [$merchant, $request]);
+        $payment->shouldReceive('getKey')->andReturn('different_sign_key');
         $notify->shouldReceive('isValid')->andReturn(true);
         $payment->shouldReceive('getNotify')->andReturn($notify);
 


### PR DESCRIPTION
沙盒模式中校驗微信支付結果通知的key應該是用沙盒key而不是商家真實key。
[微信支付商户接入验收指引](https://mp.weixin.qq.com/s?__biz=MzI0NDUzODAyOQ==&mid=100000003&idx=1&sn=6196a90ae29c213f7579cd7b8d857c64&pass_ticket=E6P9zwu5hVHOBQA3szRxxkMx8LKEwl5c1mtNvv%2BkWqE%3D)