### PR TITLE
3.1 小程序支付签名失败

### DIFF
--- a/src/Payment/Payment.php
+++ b/src/Payment/Payment.php
@@ -217,7 +217,7 @@ class Payment
     public function configForPayment($prepayId, $json = true, $mini = false)
     {
         $params = [
-            'appId' => $mini?$this->merchant->sub_app_id:$this->merchant->app_id,
+            'appId' => $mini ? $this->merchant->sub_app_id : $this->merchant->app_id,
             'timeStamp' => strval(time()),
             'nonceStr' => uniqid(),
             'package' => "prepay_id=$prepayId",

--- a/src/Payment/Payment.php
+++ b/src/Payment/Payment.php
@@ -214,10 +214,10 @@ class Payment
      *
      * @return string|array
      */
-    public function configForPayment($prepayId, $json = true)
+    public function configForPayment($prepayId, $json = true, $mini = false)
     {
         $params = [
-            'appId' => $this->merchant->app_id,
+            'appId' => $mini?$this->merchant->sub_app_id:$this->merchant->app_id,
             'timeStamp' => strval(time()),
             'nonceStr' => uniqid(),
             'package' => "prepay_id=$prepayId",


### PR DESCRIPTION
小程序`sign`生成参与的是`sub_app_id`，增加个判断 说明使用的是 小程序的支付
```
$wechat->payment->configForPayment($prepayId, $json = false, $mini = true);
```
```
 public function configForPayment($prepayId, $json = true, $mini = false)
    {
        $params = [
            'appId' => $mini ? $this->merchant->sub_app_id : $this->merchant->app_id,
            'timeStamp' => strval(time()),
            'nonceStr' => uniqid(),
            'package' => "prepay_id=$prepayId",
            'signType' => 'MD5',
        ];

        $params['paySign'] = generate_sign($params, $this->merchant->key, 'md5');

        return $json ? json_encode($params) : $params;
    }
```

另外在小程序内调起支付时。 需要 `appId` 这个参数。官方文档默认是没有的 [链接](https://mp.weixin.qq.com/debug/wxadoc/dev/api/api-pay.html#wxrequestpaymentobject)
```
{
    "appId": "wx1bd2348769f56b30" 小程序的`appId` 即配置的`sub_app_id`,
    "timeStamp": "1513574452",
    "nonceStr": "5a375034df822",
    "package": "prepay_id=wx201712181320529466435a4f0839160950",
    "signType": "MD5",
    "paySign": "F7E0DF37E204C95BA931C552AB1682BB"
}
```