### PR TITLE
微信硬件消息数据格式发生变更，修改变量命名

### DIFF
--- a/src/Server/Guard.php
+++ b/src/Server/Guard.php
@@ -362,6 +362,13 @@ class Guard
         $message = $this->getMessage();
         $response = $this->handleMessage($message);
 
+        $messageType = isset($message['msg_type']) ? $message['msg_type'] : $message['MsgType'];
+
+        if('device_text' == $messageType){
+            $message['FromUserName'] = '';
+            $message['ToUserName']   = '';
+        }
+
         return [
             'to' => $message['FromUserName'],
             'from' => $message['ToUserName'],
@@ -390,8 +397,10 @@ class Guard
 
         $message = new Collection($message);
 
-        $type = $this->messageTypeMapping[$message->get('MsgType')];
-
+        $messageType = $message->get('msg_type') ?? $message->get('MsgType');
+        
+        $type = $this->messageTypeMapping[$messageType];
+        
         $response = null;
 
         if ($this->messageFilter & $type) {

--- a/src/Server/Guard.php
+++ b/src/Server/Guard.php
@@ -397,7 +397,7 @@ class Guard
 
         $message = new Collection($message);
 
-        $messageType = $message->get('msg_type') ?? $message->get('MsgType');
+        $messageType = $message->get('msg_type', $message->get('MsgType'));
         
         $type = $this->messageTypeMapping[$messageType];
         


### PR DESCRIPTION
微信硬件消息数据格式如下：
```
{
	"device_id": "gh_e6a24fdc82b6_69b49a3ee626ee55",
	"device_type": "gh_e6a24fdc82b6",
	"msg_id": "524313758",
	"msg_type": "device_text",
	"create_time": "1516171166",
	"open_id": "o7iyW0sUwv4wH6PWhextVbtPkNVE",
	"session_id": "380219",
	"content": "AQAPAgATAwAWBAAA"
}
```