### PR TITLE
PHP的ERROR级别是一个全局设置，请不要在这个库里面修改ERROR级别

### DIFF
--- a/src/Foundation/Application.php
+++ b/src/Foundation/Application.php
@@ -121,10 +121,6 @@ class Application extends Container
             return new Config($config);
         };
 
-        if ($this['config']['debug']) {
-            error_reporting(E_ALL);
-        }
-
         $this->registerProviders();
         $this->registerBase();
         $this->initializeLogger();


### PR DESCRIPTION
昨天用了您这个微信库，但是却遇到了很多ErrorException。经过分析，发现原来是您的这个库里面把ERROR级别设置为了E_ALL。

`error_reporting(E_ALL)`是一个很好的习惯，不过请不要强加到所有人头上 -- 由于历史原因，我们的项目现在用的是PHP 5.6，error级别屏蔽了`E_NOTICE`和`E_STRICT`（大部分的NOTICE错误确实也都没必要引起注意）。

谢谢。
