### PR TITLE
响应之前需要清理输出缓存区，否则 token 验证不成功

### DIFF
--- a/src/Kernel/ServerGuard.php
+++ b/src/Kernel/ServerGuard.php
@@ -182,6 +182,8 @@ class ServerGuard
     {
         $result = $this->handleRequest();
 
+        ob_clean();
+        
         if ($this->shouldReturnRawResponse()) {
             return new Response($result['response']);
         }


### PR DESCRIPTION
Yii2 框架有时会有这个问题，网上搜了一下，也有挺多人反应用了框架会有缓存区的问题，我的项目中这个解决方案可行，但是不知道为什么。