### PR TITLE
params of redpack-info-api support both array and string

### DIFF
--- a/src/Payment/Redpack/Client.php
+++ b/src/Payment/Redpack/Client.php
@@ -24,14 +24,15 @@ class Client extends BaseClient
     /**
      * Query redpack.
      *
-     * @param array $params
+     * @param mixed $params
      *
      * @return \Psr\Http\Message\ResponseInterface|\EasyWeChat\Kernel\Support\Collection|array|object|string
      *
      * @throws \EasyWeChat\Kernel\Exceptions\InvalidConfigException
      */
-    public function info(array $params)
+    public function info($mchBillno)
     {
+        $params = is_array($mchBillno) ? $mchBillno : ['mch_billno' => $mchBillno];
         $base = [
             'appid' => $this->app['config']->app_id,
             'bill_type' => 'MCHT',


### PR DESCRIPTION
红包查询接口的参数，同时支持字符串和数组。
这样和文档里的例子是一致的

```php
$mchBillNo = "商户系统内部的订单号（mch_billno）";
$redpack->info($mchBillNo);
```