### PR TITLE
修复企业付款到银行卡查询时报签名错误

### DIFF
--- a/src/Payment/Transfer/Client.php
+++ b/src/Payment/Transfer/Client.php
@@ -80,7 +80,6 @@ class Client extends BaseClient
     {
         $params = [
             'mch_id' => $this->app['config']->mch_id,
-            'appid' => $this->app['config']->app_id,
             'partner_trade_no' => $partnerTradeNo,
         ];
 


### PR DESCRIPTION
查询企业付款到银行卡时不需要传appid