### PR TITLE
配置的日志驱动不合法时，使用默认日志驱动，而导致的临时目录下文件夹不可写的问题。

### DIFF
--- a/src/Kernel/Log/LogManager.php
+++ b/src/Kernel/Log/LogManager.php
@@ -171,7 +171,7 @@ class LogManager implements LoggerInterface
     protected function createEmergencyLogger()
     {
         return new Monolog('EasyWeChat', $this->prepareHandlers([new StreamHandler(
-            \sys_get_temp_dir().'/logs/easywechat.log', $this->level(['level' => 'debug'])
+            \sys_get_temp_dir().'/easywechat_logs/easywechat.log', $this->level(['level' => 'debug'])
         )]));
     }
 

--- a/src/Kernel/Log/LogManager.php
+++ b/src/Kernel/Log/LogManager.php
@@ -171,7 +171,7 @@ class LogManager implements LoggerInterface
     protected function createEmergencyLogger()
     {
         return new Monolog('EasyWeChat', $this->prepareHandlers([new StreamHandler(
-            \sys_get_temp_dir().'/easywechat_logs/easywechat.log', $this->level(['level' => 'debug'])
+            \sys_get_temp_dir().'/easywechat/easywechat.log', $this->level(['level' => 'debug'])
         )]));
     }
 


### PR DESCRIPTION
配置的日志驱动不合法时，触发 createEmergencyLogger 方法（创建默认日志驱动），但是如果有其它以 root 身份执行的进程首先创建 logs 文件夹，PHP 对该文件夹不可写。