### PR TITLE
不该重写timeStamp为小写

### DIFF
--- a/src/Payment/Jssdk/Client.php
+++ b/src/Payment/Jssdk/Client.php
@@ -66,10 +66,6 @@ class Client extends JssdkClient
     public function sdkConfig(string $prepayId): array
     {
         $config = $this->bridgeConfig($prepayId, false);
-
-        $config['timestamp'] = $config['timeStamp'];
-        unset($config['timeStamp']);
-
         return $config;
     }
 


### PR DESCRIPTION
官方示例:
https://pay.weixin.qq.com/wiki/doc/api/jsapi.php?chapter=7_7&index=6
```
function onBridgeReady(){
   WeixinJSBridge.invoke(
       'getBrandWCPayRequest', {
           "appId":"wx2421b1c4370ec43b",     //公众号名称，由商户传入     
           "timeStamp":"1395712654",         //时间戳，自1970年以来的秒数     
           "nonceStr":"e61463f8efa94090b1f366cccfbbb444", //随机串     
           "package":"prepay_id=u802345jgfjsdfgsdg888",     
           "signType":"MD5",         //微信签名方式：     
           "paySign":"70EA570631E4BB79628FBCA90534C63FF7FADD89" //微信签名 
       },
       function(res){     
           if(res.err_msg == "get_brand_wcpay_request:ok" ) {}     // 使用以上方式判断前端返回,微信团队郑重提示：res.err_msg将在用户支付成功后返回    ok，但并不保证它绝对可靠。 
       }
   ); 
}
if (typeof WeixinJSBridge == "undefined"){
   if( document.addEventListener ){
       document.addEventListener('WeixinJSBridgeReady', onBridgeReady, false);
   }else if (document.attachEvent){
       document.attachEvent('WeixinJSBridgeReady', onBridgeReady); 
       document.attachEvent('onWeixinJSBridgeReady', onBridgeReady);
   }
}else{
   onBridgeReady();
}
```