### PR TITLE
update Messenger.php

### DIFF
--- a/src/Work/Message/Messenger.php
+++ b/src/Work/Message/Messenger.php
@@ -137,6 +137,18 @@ class Messenger
     }
 
     /**
+     * Undo secret.
+     *
+     * @return \EasyWeChat\Work\Message\Messenger
+     */
+    public function unSecretive()
+    {
+        $this->secretive = false;
+
+        return $this;
+    }
+
+    /**
      * @param array|string $ids
      * @param string       $key
      *


### PR DESCRIPTION
企业微信主动发消息, 当作为单例使用(如使用laravel, 注册为服务并使用laravel队列), 
设置过Messanger::secretive()之后, 之后发送的消息都为保密消息. 

增加了Messanger::unSecretive()方法, 可将secretive改为false