### PR TITLE
Remove "linting" config option

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,7 +1,5 @@
 preset: symfony
 
-linting: true
-
 enabled:
   - strict
   - strict_param


### PR DESCRIPTION
* https://styleci.readme.io/docs/change-log#section-14042018-april-fixer-updates
* Finally, the long deprecated "linting" config option has now been removed.