### PR TITLE
fix authorizer miniprogram does not use configured cache

### DIFF
--- a/src/OpenPlatform/Application.php
+++ b/src/OpenPlatform/Application.php
@@ -157,7 +157,7 @@ class Application extends ServiceContainer
             'server' => function ($app) {
                 return new Guard($app);
             },
-            'cache' => $this['cache'],
+            'cache' => $this['cache'] ?? null,
         ];
     }
 

--- a/src/OpenPlatform/Application.php
+++ b/src/OpenPlatform/Application.php
@@ -157,6 +157,7 @@ class Application extends ServiceContainer
             'server' => function ($app) {
                 return new Guard($app);
             },
+            'cache' => $this['cache'],
         ];
     }
 


### PR DESCRIPTION
通过三方平台生成一个授权的小程序实例, 然后检查该实例的cache属性发现这里返回的null, 这样就始终在用默认的/tmp缓存而不是laravel自己的cache.store. 导致多机的时候总是invalid access token

代码如下:
```
$openPlatform = app('wechat.open_platform.default');
$miniProgram = $openPlatform->miniProgram('some id', 'some token');
$miniProgram->access_token->getToken(); 
```
然后追踪到缓存部分.
```
trait InteractsWithCache
{
  public function getCache()
    {
       ...
        if (property_exists($this, 'app') && $this->app instanceof ServiceContainer
            && isset($this->app['cache']) && $this->app['cache'] instanceof CacheInterface) {
            return $this->cache = $this->app['cache'];
        }
       ...
        return $this->cache = $this->createDefaultCache();
    }
}
```
` isset($this->app['cache'])`这个语句始终返回null , 此时的 `$this->app` 值为 `EasyWeChat\OpenPlatform\Authorizer\MiniProgram\Application`. 
再找到 'EasyWeChat\OpenPlatform\Application`这个类
```
  public function miniProgram(string $appId, string $refreshToken = null, AccessToken $accessToken = null): MiniProgram
    {
        return new MiniProgram($this->getAuthorizerConfig($appId, $refreshToken), $this->getReplaceServices($accessToken) + [
            'encryptor' => function () {
                return new Encryptor($this['config']['app_id'], $this['config']['token'], $this['config']['aes_key']);
            },

            'auth' => function ($app) {
                return new Client($app, $this);
            },
        ]);
    }
```
如果我没有理解错的话, 这里实例化miniprotram的时候没有把当前应用的cache传进去. 所以后面获取cache的时候返回的是null. 所以在这里添加代码, 把OpenPlatform的cache实例传递给Miniprogram