### PR TITLE
避免发模板消息时miniprogram参数传空时报错

### DIFF
--- a/src/Notice/Notice.php
+++ b/src/Notice/Notice.php
@@ -47,6 +47,7 @@ class Notice extends AbstractAPI
         'template_id' => '',
         'url' => '',
         'data' => [],
+        'miniprogram' => ''
     ];
 
     /**


### PR DESCRIPTION
发现如果调notice->send方法中“miniprogram”传空。notice 在处理时会报错。看了一下源码。帮忙修正一下。