### PR TITLE
调整授权方 access_token 和 refresh_token 的缓存名称

### DIFF
--- a/src/OpenPlatform/Authorizer.php
+++ b/src/OpenPlatform/Authorizer.php
@@ -184,7 +184,7 @@ class Authorizer
      */
     public function getAccessTokenCacheKey()
     {
-        return self::CACHE_KEY_ACCESS_TOKEN.$this->appId.$this->getAppId();
+        return self::CACHE_KEY_ACCESS_TOKEN.'.'.$this->openPlatformAppId.'.'.$this->getAppId();
     }
 
     /**
@@ -194,6 +194,6 @@ class Authorizer
      */
     public function getRefreshTokenCacheKey()
     {
-        return self::CACHE_KEY_REFRESH_TOKEN.$this->appId.$this->getAppId();
+        return self::CACHE_KEY_REFRESH_TOKEN.'.'.$this->openPlatformAppId.'.'.$this->getAppId();
     }
 }


### PR DESCRIPTION
* 🤔 缓存名称不应该包含两个授权方的AppId
* 添加分隔符 .(点）