### PR TITLE
新增客服消息类型-小程序卡片。

### DIFF
--- a/src/Message/MiniProgramPage.php
+++ b/src/Message/MiniProgramPage.php
@@ -1,0 +1,40 @@
+<?php
+/*
+ * This file is part of the overtrue/wechat.
+ *
+ * (c) overtrue <i@overtrue.me>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+
+namespace EasyWeChat\Message;
+
+
+class MiniProgramPage extends AbstractMessage
+{
+
+    protected $type = "miniprogrampage";
+
+    protected $properties = [
+        'title',
+        'appid',
+        'pagepath',
+        'thumb_media_id',
+    ];
+
+    /**
+     * 小程序卡片图片的媒体ID，小程序卡片图片建议大小为520*416
+     * mediaId需后台通过api上传后获取
+     * @param string $mediaId
+     *
+     * @return $this
+     */
+    public function thumb($mediaId)
+    {
+        $this->setAttribute('thumb_media_id', $mediaId);
+
+        return $this;
+    }
+}

--- a/src/Staff/Transformer.php
+++ b/src/Staff/Transformer.php
@@ -194,4 +194,22 @@ class Transformer
                             ],
                ];
     }
+
+    /**
+     * Transform minprogrampage message
+     * @return  array
+     */
+    public function transformMiniProgramPage(AbstractMessage $message){
+        $type = $message->getType();
+
+        return [
+            'msgtype' => $type,
+            $type     => [
+                'title'          => $message->get('title'),
+                'appid'          => $message->get('appid'),
+                'pagepath'       => $message->get('pagepath'),
+                'thumb_media_id' => $message->get('thumb_media_id'),
+            ],
+        ];
+    }
 }

--- a/tests/Staff/StaffTransformerTest.php
+++ b/tests/Staff/StaffTransformerTest.php
@@ -13,6 +13,7 @@ namespace EasyWeChat\Tests\Staff;
 
 use EasyWeChat\Message\Image;
 use EasyWeChat\Message\Link;
+use EasyWeChat\Message\MiniProgramPage;
 use EasyWeChat\Message\News;
 use EasyWeChat\Message\Text;
 use EasyWeChat\Message\Video;
@@ -120,5 +121,27 @@ class StaffTransformerTest extends TestCase
         $this->assertEquals('news', $result['msgtype']);
         $this->assertEquals('foo', $result['news']['articles'][0]['title']);
         $this->assertEquals('bar', $result['news']['articles'][1]['title']);
+    }
+
+    /**
+     * Test transformMiniProgramPage()
+     */
+    public function testTransformMiniProgramPage()
+    {
+        $message = new MiniProgramPage();
+        $message->title = 'a staff message that type is miniprogrampage';
+        $message->appid = 'appid';
+        $message->pagepath = 'page/main?a=b';
+        $message->thumb('miniprogram cover');
+
+
+        $transformer = new Transformer();
+
+        $result = $transformer->transform($message);
+        $this->assertEquals('miniprogrampage', $result['msgtype']);
+        $this->assertEquals('a staff message that type is miniprogrampage', $result['miniprogrampage']['title']);
+        $this->assertEquals('appid', $result['miniprogrampage']['appid']);
+        $this->assertEquals('page/main?a=b', $result['miniprogrampage']['pagepath']);
+        $this->assertEquals('miniprogram cover', $result['miniprogrampage']['thumb_media_id']);
     }
 }


### PR DESCRIPTION
微信的客服消息新增了小程序卡片类型。目前如果想要发送该类型的消息。需要手动封装消息内容。然后发送消息。

![image](https://user-images.githubusercontent.com/2074921/42209700-e5d58cae-7ee1-11e8-8a77-093976c7f260.png)

新增MiniProgramPage类。并增加相应的transform方法。可以和其他类型消息一样发送。
![image](https://user-images.githubusercontent.com/2074921/42209917-795a58ce-7ee2-11e8-87f8-42e30ab1e988.png)
