### PR TITLE
新增小程序卡片类型消息和模板消息兼容miniprogram字段

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,15 +17,15 @@
     "require": {
         "php": ">=7.0",
         "ext-openssl": "*",
-        "ext-simplexml":"*",
-        "pimple/pimple": "^3.0",
+        "ext-simplexml": "*",
+        "easywechat-composer/easywechat-composer": "^1.0",
+        "guzzlehttp/guzzle": "^6.2",
         "monolog/monolog": "^1.22",
         "overtrue/socialite": "~2.0",
-        "guzzlehttp/guzzle": "^6.2",
-        "symfony/http-foundation": "^2.7|^3.0|^4.0",
-        "symfony/psr-http-message-bridge": "^0.3|^1.0",
+        "pimple/pimple": "^3.0",
         "symfony/cache": "^3.3|^4.0",
-        "easywechat-composer/easywechat-composer": "^0.1"
+        "symfony/http-foundation": "^2.7|^3.0|^4.0",
+        "symfony/psr-http-message-bridge": "^0.3|^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~6.0",

--- a/src/Kernel/Messages/MiniProgramPage.php
+++ b/src/Kernel/Messages/MiniProgramPage.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the overtrue/wechat.
+ *
+ * (c) overtrue <i@overtrue.me>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace EasyWeChat\Kernel\Messages;
+
+/**
+ * Class MiniProgramPage.
+ */
+class MiniProgramPage extends Message
+{
+    protected $type = 'miniprogrampage';
+
+    protected $properties = [
+        'title',
+        'appid',
+        'pagepath',
+        'thumb_media_id',
+    ];
+
+    protected $required = [
+        'thumb_media_id', 'appid', 'pagepath',
+    ];
+}

--- a/src/Kernel/Support/Helpers.php
+++ b/src/Kernel/Support/Helpers.php
@@ -80,7 +80,7 @@ function current_url()
 {
     $protocol = 'http://';
 
-    if (!empty($_SERVER['HTTPS']) || ($_SERVER['HTTP_X_FORWARDED_PROTO'] ?? 'http') === 'https') {
+    if ((!empty($_SERVER['HTTPS']) && 'off' !== $_SERVER['HTTPS']) || ($_SERVER['HTTP_X_FORWARDED_PROTO'] ?? 'http') === 'https') {
         $protocol = 'https://';
     }
 

--- a/src/OfficialAccount/TemplateMessage/Client.php
+++ b/src/OfficialAccount/TemplateMessage/Client.php
@@ -34,6 +34,7 @@ class Client extends BaseClient
         'template_id' => '',
         'url' => '',
         'data' => [],
+        'miniprogram' => '',
     ];
 
     /**

--- a/src/OpenPlatform/Authorizer/MiniProgram/Code/Client.php
+++ b/src/OpenPlatform/Authorizer/MiniProgram/Code/Client.php
@@ -111,6 +111,14 @@ class Client extends BaseClient
     }
 
     /**
+     * @return array|\EasyWeChat\Kernel\Support\Collection|object|\Psr\Http\Message\ResponseInterface|string
+     */
+    public function rollbackRelease()
+    {
+        return $this->httpGet('wxa/revertcoderelease');
+    }
+
+    /**
      * @param string $action
      *
      * @return array|\EasyWeChat\Kernel\Support\Collection|object|\Psr\Http\Message\ResponseInterface|string

--- a/tests/Kernel/Messages/MiniProgramPageTest.php
+++ b/tests/Kernel/Messages/MiniProgramPageTest.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the overtrue/wechat.
+ *
+ * (c) overtrue <i@overtrue.me>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace EasyWeChat\Tests\Kernel\Messages;
+
+use EasyWeChat\Kernel\Messages\MiniProgramPage;
+use EasyWeChat\Tests\TestCase;
+
+class MiniProgramPageTest extends TestCase
+{
+    public function testBasicFeatures()
+    {
+        $msg = new MiniProgramPage([
+            'title' => 'title',
+            'appid' => 'minprogram appid',
+            'pagepath' => 'miniprogram path',
+            'thumb_media_id' => 'miniprogram cover',
+        ]);
+
+        $this->assertSame('title', $msg->get('title'));
+        $this->assertSame('minprogram appid', $msg->get('appid'));
+        $this->assertSame('miniprogram path', $msg->get('pagepath'));
+        $this->assertSame('miniprogram cover', $msg->get('thumb_media_id'));
+
+        $this->assertSame('miniprogrampage', $msg->getType());
+        $msg->set('title', 'title1');
+
+        $this->assertSame('title1', $msg->title);
+
+        $msg->thumb_media_id = 'image2';
+
+        $this->assertSame('image2', $msg->get('thumb_media_id'));
+    }
+
+    public function testTransformForJsonRequest()
+    {
+        $msg = new MiniProgramPage();
+        $msg->title = 'title';
+        $msg->appid = 'appid';
+        $msg->thumb_media_id = 'image';
+        $msg->pagepath = 'path';
+
+        $this->assertSame(
+            [
+                'msgtype' => 'miniprogrampage',
+                'miniprogrampage' => [
+                    'title' => 'title',
+                    'appid' => 'appid',
+                    'thumb_media_id' => 'image',
+                    'pagepath' => 'path',
+                ],
+            ],
+            $msg->transformForJsonRequest()
+        );
+    }
+}

--- a/tests/OfficialAccount/TemplateMessage/ClientTest.php
+++ b/tests/OfficialAccount/TemplateMessage/ClientTest.php
@@ -90,6 +90,19 @@ class ClientTest extends TestCase
             'miniprogram' => '',
         ])->andReturn('mock-result')->once();
         $this->assertSame('mock-result', $client->send(['touser' => 'mock-openid', 'template_id' => 'mock-template_id']));
+
+        // with miniprogram
+        $client->expects()->httpPostJson('cgi-bin/message/template/send', [
+            'touser' => 'mock-openid',
+            'template_id' => 'mock-template_id',
+            'url' => '',
+            'data' => [],
+            'miniprogram' => [
+                'appid' => 'id',
+                'pagepath' => 'path',
+            ],
+        ])->andReturn('mock-result')->once();
+        $this->assertSame('mock-result', $client->send(['touser' => 'mock-openid', 'template_id' => 'mock-template_id', 'miniprogram' => ['appid' => 'id', 'pagepath' => 'path']]));
     }
 
     public function testFormatData()
@@ -125,6 +138,7 @@ class ClientTest extends TestCase
             'template_id' => 'mock-template_id',
             'url' => '',
             'data' => [],
+            'miniprogram' => '',
         ])->andReturn('mock-result')->once();
         $this->assertSame('mock-result', $client->sendSubscription(['touser' => 'mock-openid', 'template_id' => 'mock-template_id']));
 
@@ -137,6 +151,7 @@ class ClientTest extends TestCase
                 'data' => [
                     'content' => ['value' => 'VALUE'],
                 ],
+            'miniprogram' => '',
         ])->andReturn('mock-result')->once();
 
         $this->assertSame('mock-result', $client->sendSubscription([

--- a/tests/OfficialAccount/TemplateMessage/ClientTest.php
+++ b/tests/OfficialAccount/TemplateMessage/ClientTest.php
@@ -87,6 +87,7 @@ class ClientTest extends TestCase
             'template_id' => 'mock-template_id',
             'url' => '',
             'data' => [],
+            'miniprogram' => '',
         ])->andReturn('mock-result')->once();
         $this->assertSame('mock-result', $client->send(['touser' => 'mock-openid', 'template_id' => 'mock-template_id']));
     }


### PR DESCRIPTION
1：新增了小程序卡片消息类`MiniProgramPage`，发送客服消息时可以使用。
2：发送模板消息时可以添加`miniprogram`字段。