### PR TITLE
fix Music Message reply with ThumbMediaId option

### DIFF
--- a/src/Kernel/Messages/Music.php
+++ b/src/Kernel/Messages/Music.php
@@ -46,14 +46,17 @@ class Music extends Message
 
     public function toXmlArray()
     {
-        return [
+        $music = [
             'Music' => [
                 'Title' => $this->get('title'),
                 'Description' => $this->get('description'),
                 'MusicUrl' => $this->get('url'),
                 'HQMusicUrl' => $this->get('hq_url'),
-                'ThumbMediaId' => $this->get('thumb_media_id'),
             ],
         ];
+        if ($thumbMediaId = $this->get('thumb_media_id')) {
+            $music['ThumbMediaId'] = $thumbMediaId;
+        }
+        return $music;
     }
 }

--- a/src/Kernel/Messages/Music.php
+++ b/src/Kernel/Messages/Music.php
@@ -57,7 +57,7 @@ class Music extends Message
         if ($thumbMediaId = $this->get('thumb_media_id')) {
             $music['ThumbMediaId'] = $thumbMediaId;
         }
-        
+
         return $music;
     }
 }

--- a/src/Kernel/Messages/Music.php
+++ b/src/Kernel/Messages/Music.php
@@ -57,6 +57,7 @@ class Music extends Message
         if ($thumbMediaId = $this->get('thumb_media_id')) {
             $music['ThumbMediaId'] = $thumbMediaId;
         }
+        
         return $music;
     }
 }


### PR DESCRIPTION
修复回复音乐消息，未认证公众号没有临时素材和永久素材管理权限。故无法提供ThumbMediaId，虽然官方文档显示ThumbMediaId未必选项，但实际上是可选项。