### PR TITLE
企业微信第三方服务商修复

### DIFF
--- a/src/OpenWork/Corp/Client.php
+++ b/src/OpenWork/Corp/Client.php
@@ -75,7 +75,7 @@ class Client extends BaseClient
      */
     public function setSession(array $data)
     {
-        return $this->httpPostJson('cgi-bin/service/set_session_info', compact('data'));
+        return $this->httpPostJson('cgi-bin/service/set_session_info', $data);
     }
 
     /**

--- a/src/OpenWork/SuiteAuth/SuiteTicket.php
+++ b/src/OpenWork/SuiteAuth/SuiteTicket.php
@@ -73,6 +73,6 @@ class SuiteTicket
      */
     protected function getCacheKey(): string
     {
-        return 'easywechat.open_work.suite_ticket.'.$this->app['config']['corp_id'];
+        return 'easywechat.open_work.suite_ticket.'.$this->app['config']['corp_id'].$this->app['config']['suite_id'];
     }
 }


### PR DESCRIPTION
* 修复设置授权配置时,系统提示参数为空的问题
* 修复系统存在多个第三方应用时,各个应用的suite_ticket相互覆盖,导致请求失败的问题(suite_ticket按服务商ID-应用ID区分)



