### PR TITLE
消息处理器条件判断

### DIFF
--- a/src/Kernel/Clauses/Clause.php
+++ b/src/Kernel/Clauses/Clause.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the overtrue/wechat.
+ *
+ * (c) overtrue <i@overtrue.me>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace EasyWeChat\Kernel\Clauses;
+
+/**
+ * Class Clause.
+ *
+ * @author mingyoung <mingyoungcheung@gmail.com>
+ */
+class Clause
+{
+    /**
+     * @var array
+     */
+    protected $clauses = [
+        'where' => [],
+    ];
+
+    /**
+     * @param string $key
+     * @param string $value
+     *
+     * @return $this
+     */
+    public function where(...$args)
+    {
+        array_push($this->clauses['where'], $args);
+
+        return $this;
+    }
+
+    /**
+     * @param mixed $payload
+     *
+     * @return bool
+     */
+    public function intercepted($payload)
+    {
+        return (bool) $this->interceptWhereClause($payload);
+    }
+
+    /**
+     * @param mixed $payload
+     *
+     * @return bool
+     */
+    protected function interceptWhereClause($payload)
+    {
+        foreach ($this->clauses['where'] as [$key, $value]) {
+            if (isset($payload[$key]) && $payload[$key] !== $value) {
+                return true;
+            }
+        }
+    }
+}

--- a/tests/Kernel/Traits/ObservableTest.php
+++ b/tests/Kernel/Traits/ObservableTest.php
@@ -306,6 +306,30 @@ class ObservableTest extends TestCase
             $this->assertSame('No valid handler is found in arguments.', $e->getMessage());
         }
     }
+
+    public function testWhereClause()
+    {
+        $c = new DummyClassForObservableTest();
+        $handler1 = \Mockery::mock(EventHandlerInterface::class);
+        $handler1->allows()->handle(['Type' => 'testing'])->andReturn('handler1-response');
+        $c->push($handler1)->where('Type', 'staging');
+
+        $this->assertNull($c->notify('foo', ['Type' => 'testing']));
+
+        $c2 = new DummyClassForObservableTest();
+        $handler2 = \Mockery::mock(EventHandlerInterface::class);
+        $handler2->allows()->handle(['Type' => 'testing'])->andReturn('handler2-response');
+        $c2->push($handler2)->where('Type', 'testing');
+
+        $this->assertSame('handler2-response', $c2->notify('foo', ['Type' => 'testing']));
+
+        $c3 = new DummyClassForObservableTest();
+        $handler3 = \Mockery::mock(EventHandlerInterface::class);
+        $handler3->allows()->handle(['Type' => 'testing', 'User' => 'user-123'])->andReturn('handler3-response');
+        $c3->push($handler3)->where('Type', 'testing')->where('User', 'user-456');
+
+        $this->assertNull($c3->notify('foo', ['Type' => 'testing', 'User' => 'user-123']));
+    }
 }
 
 class DummyHandlerClassForObservableTest implements EventHandlerInterface


### PR DESCRIPTION
如：只处理 MsgType 为 Event 下的领取卡券的事件：

```php
$server->push(YourHandler::class, Message::EVENT)->where('Event', 'user_get_card');
```

支持多个 where 语句：
```php
$server->push(YourHandler::class, Message::EVENT)
    ->where('Event', 'user_get_card')
    ->where('CardId', 'pZI8Fjwsy5fVPRBeD78J4RmqVvBc');
```