### PR TITLE
Fix UTF8 Encoding issues in some rare cases

### DIFF
--- a/src/Core/Http.php
+++ b/src/Core/Http.php
@@ -264,7 +264,7 @@ class Http
     public function parseJSON($body)
     {
         if ($body instanceof ResponseInterface) {
-            $body = $body->getBody();
+            $body = mb_convert_encoding($body->getBody(), 'UTF-8');
         }
 
         // XXX: json maybe contains special chars. So, let's FUCK the WeChat API developers ...

--- a/src/Core/Http.php
+++ b/src/Core/Http.php
@@ -267,6 +267,9 @@ class Http
             $body = $body->getBody();
         }
 
+        \Log::info('On est bien la');
+        die();
+
         // XXX: json maybe contains special chars. So, let's FUCK the WeChat API developers ...
         $body = $this->fuckTheWeChatInvalidJSON($body);
 

--- a/src/Core/Http.php
+++ b/src/Core/Http.php
@@ -264,7 +264,7 @@ class Http
     public function parseJSON($body)
     {
         if ($body instanceof ResponseInterface) {
-            $body = utf8_encode($body->getBody());
+            $body = $body->getBody();
         }
 
         // XXX: json maybe contains special chars. So, let's FUCK the WeChat API developers ...

--- a/src/Core/Http.php
+++ b/src/Core/Http.php
@@ -264,11 +264,8 @@ class Http
     public function parseJSON($body)
     {
         if ($body instanceof ResponseInterface) {
-            $body = $body->getBody();
+            $body = utf8_encode($body->getBody());
         }
-
-        \Log::info('On est bien la');
-        die();
 
         // XXX: json maybe contains special chars. So, let's FUCK the WeChat API developers ...
         $body = $this->fuckTheWeChatInvalidJSON($body);


### PR DESCRIPTION
When pulling information about followers, I discovered that for some of them your method to "fuck" wechat API developers did not work. The fix is to ensure everything is well encoded to UTF-8.

Sorry for the first 3 useless commits.