### PR TITLE
方法 `getHttpClient` 返回值用ClientInterface代替Client。

### DIFF
--- a/src/Kernel/BaseClient.php
+++ b/src/Kernel/BaseClient.php
@@ -15,6 +15,7 @@ use EasyWeChat\Kernel\Contracts\AccessTokenInterface;
 use EasyWeChat\Kernel\Http\Response;
 use EasyWeChat\Kernel\Traits\HasHttpRequests;
 use GuzzleHttp\Client;
+use GuzzleHttp\ClientInterface;
 use GuzzleHttp\MessageFormatter;
 use GuzzleHttp\Middleware;
 use Psr\Http\Message\RequestInterface;
@@ -192,9 +193,9 @@ class BaseClient
      *
      * @return \GuzzleHttp\Client
      */
-    public function getHttpClient(): Client
+    public function getHttpClient(): ClientInterface
     {
-        if (!($this->httpClient instanceof Client)) {
+        if (!($this->httpClient instanceof ClientInterface)) {
             $this->httpClient = $this->app['http_client'] ?? new Client();
         }
 

--- a/src/Kernel/BaseClient.php
+++ b/src/Kernel/BaseClient.php
@@ -189,9 +189,9 @@ class BaseClient
     }
 
     /**
-     * Return GuzzleHttp\Client instance.
+     * Return ClientInterface instance.
      *
-     * @return \GuzzleHttp\Client
+     * @return ClientInterface
      */
     public function getHttpClient(): ClientInterface
     {

--- a/src/Kernel/BaseClient.php
+++ b/src/Kernel/BaseClient.php
@@ -189,7 +189,7 @@ class BaseClient
     }
 
     /**
-     * Return ClientInterface instance.
+     * Return GuzzleHttp\ClientInterface instance.
      *
      * @return ClientInterface
      */

--- a/src/Kernel/Traits/HasHttpRequests.php
+++ b/src/Kernel/Traits/HasHttpRequests.php
@@ -84,9 +84,9 @@ trait HasHttpRequests
     }
 
     /**
-     * Return GuzzleHttp\Client instance.
+     * Return ClientInterface instance.
      *
-     * @return \GuzzleHttp\Client
+     * @return ClientInterface
      */
     public function getHttpClient(): ClientInterface
     {

--- a/src/Kernel/Traits/HasHttpRequests.php
+++ b/src/Kernel/Traits/HasHttpRequests.php
@@ -84,7 +84,7 @@ trait HasHttpRequests
     }
 
     /**
-     * Return ClientInterface instance.
+     * Return GuzzleHttp\ClientInterface instance.
      *
      * @return ClientInterface
      */

--- a/src/Kernel/Traits/HasHttpRequests.php
+++ b/src/Kernel/Traits/HasHttpRequests.php
@@ -88,7 +88,7 @@ trait HasHttpRequests
      *
      * @return \GuzzleHttp\Client
      */
-    public function getHttpClient(): Client
+    public function getHttpClient(): ClientInterface
     {
         if (!($this->httpClient instanceof ClientInterface)) {
             $this->httpClient = new Client();


### PR DESCRIPTION
当我把服务跑在Swoole里时，希望使用Swoole的协程Client，所以我需要重写http_client，并继承了GuzzleHttp\\ClientInterface。

但是，以下方法锁定了返回类型为Client，所以希望这里可以稍微修改成ClientInterface，方便用户自己注入需要用的HttpClient

~~~
    /**
     * Return GuzzleHttp\Client instance.
     *
     * @return \GuzzleHttp\Client
     */
    public function getHttpClient(): Client
    {
        if (!($this->httpClient instanceof ClientInterface)) {
            $this->httpClient = new Client();
        }

        return $this->httpClient;
    }
~~~