### PR TITLE
修复windows系统下单元测试异常

### DIFF
--- a/tests/Kernel/Http/StreamResponseTest.php
+++ b/tests/Kernel/Http/StreamResponseTest.php
@@ -53,8 +53,9 @@ class StreamResponseTest extends TestCase
 
         // not writable
         $this->expectException(\EasyWeChat\Kernel\Exceptions\InvalidArgumentException::class);
-        $this->expectExceptionMessage("'/usr' is not writable.");
-        $response->save('/usr');
+        $this->expectExceptionMessage("'vfs://usr' is not writable.");
+        vfsStream::setup('usr', 0444);
+        $response->save(vfsStream::url('usr'));
     }
 
     public function testSaveAs()


### PR DESCRIPTION
StreamResponseTest类的testSave方法在windows操作系统下断言失败，提示如下：

> Failed asserting that exception of type "EasyWeChat\Kernel\Exceptions\InvalidArgumentException" is thrown.