### PR TITLE
小程序添加统一消息接口支持

### DIFF
--- a/src/MiniProgram/Application.php
+++ b/src/MiniProgram/Application.php
@@ -30,6 +30,7 @@ use EasyWeChat\Kernel\ServiceContainer;
  * @property \EasyWeChat\BasicService\Media\Client              $media
  * @property \EasyWeChat\BasicService\ContentSecurity\Client    $content_security
  * @property \EasyWeChat\MiniProgram\Plugin\Client              $plugin
+ * @property \EasyWeChat\MiniProgram\UniformMessage\Client              $uniform_message
  */
 class Application extends ServiceContainer
 {
@@ -43,6 +44,7 @@ class Application extends ServiceContainer
         Server\ServiceProvider::class,
         TemplateMessage\ServiceProvider::class,
         CustomerService\ServiceProvider::class,
+        UniformMessage\ServiceProvider::class,
         // Base services
         BasicService\Media\ServiceProvider::class,
         BasicService\ContentSecurity\ServiceProvider::class,

--- a/src/MiniProgram/UniformMessage/Client.php
+++ b/src/MiniProgram/UniformMessage/Client.php
@@ -1,0 +1,135 @@
+<?php
+
+/*
+ * This file is part of the overtrue/wechat.
+ *
+ * (c) overtrue <i@overtrue.me>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace EasyWeChat\MiniProgram\UniformMessage;
+
+use EasyWeChat\Factory;
+use EasyWeChat\Kernel\Exceptions\InvalidArgumentException;
+use EasyWeChat\OfficialAccount\TemplateMessage\Client as BaseClient;
+
+class Client extends BaseClient
+{
+    const API_SEND = 'cgi-bin/message/wxopen/template/uniform_send';
+
+    /**
+     * {@inheritdoc}.
+     *
+     * @var array
+     */
+    protected $message = [
+        'touser' => '',
+    ];
+
+    /**
+     * Weapp Attributes.
+     *
+     * @var array
+     */
+    protected $weappMessage = [
+        'template_id' => '',
+        'page' => '',
+        'form_id' => '',
+        'data' => [],
+        'emphasis_keyword' => '',
+    ];
+
+    /**
+     * Official account attributes.
+     *
+     * @var array
+     */
+    protected $mpMessage = [
+        'appid' => '',
+        'template_id' => '',
+        'url' => '',
+        'miniprogram' => [],
+        'data' => [],
+    ];
+
+    /**
+     * Required attributes.
+     *
+     * @var array
+     */
+    protected $required = ['touser', 'template_id', 'form_id', 'miniprogram', 'appid'];
+
+    /**
+     * @param array $data
+     *
+     * @return array
+     */
+    protected function formatMessage(array $data = [])
+    {
+        $params = $this->baseFormat($data, $this->message);
+
+        if (!empty($params['weapp_template_msg'])) {
+            $params['weapp_template_msg'] = $this->formatWeappMessage($params['weapp_template_msg']);
+        }
+
+        if (!empty($params['mp_template_msg'])) {
+            $params['mp_template_msg'] = $this->formatMpMessage($params['mp_template_msg']);
+        }
+
+        return $params;
+    }
+
+    /**
+     * @param array $data
+     * @return array
+     */
+    protected function formatWeappMessage(array $data = [])
+    {
+        $params = $this->baseFormat($data, $this->weappMessage);
+
+        $params['data'] = $this->formatData($params['data'] ?? []);
+
+        return $params;
+    }
+
+    /**
+     * @param array $data
+     * @return array
+     */
+    protected function formatMpMessage(array $data = [])
+    {
+        $params = $this->baseFormat($data, $this->mpMessage);
+
+        if (empty($params['miniprogram']['appid'])) {
+            $params['miniprogram']['appid'] = $this->app['config']['app_id'];
+        }
+
+        $params['data'] = $this->formatData($params['data'] ?? []);
+
+        return $params;
+    }
+
+    /**
+     * @param array $data
+     * @param array $default
+     *
+     * @return array
+     *
+     * @throws \EasyWeChat\Kernel\Exceptions\InvalidArgumentException
+     */
+    protected function baseFormat($data = [], $default = [])
+    {
+        $params = array_merge($default, $data);
+        foreach ($params as $key => $value) {
+            if (in_array($key, $this->required, true) && empty($value) && empty($default[$key])) {
+                throw new InvalidArgumentException(sprintf('Attribute "%s" can not be empty!', $key));
+            }
+
+            $params[$key] = empty($value) ? $default[$key] : $value;
+        }
+
+        return $params;
+    }
+}

--- a/src/MiniProgram/UniformMessage/ServiceProvider.php
+++ b/src/MiniProgram/UniformMessage/ServiceProvider.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the overtrue/wechat.
+ *
+ * (c) overtrue <i@overtrue.me>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace EasyWeChat\MiniProgram\UniformMessage;
+
+use Pimple\Container;
+use Pimple\ServiceProviderInterface;
+
+class ServiceProvider implements ServiceProviderInterface
+{
+    /**
+     * {@inheritdoc}.
+     */
+    public function register(Container $app)
+    {
+        $app['uniform_message'] = function ($app) {
+            return new Client($app);
+        };
+    }
+}


### PR DESCRIPTION
https://developers.weixin.qq.com/miniprogram/dev/api/open-api/uniform-message/sendUniformMessage.html

调用方法：
```php
$miniProgram->uniform_message->send([
    'touser' => 'user openid',
    'weapp_template_msg' => [
        'template_id' => 'template_id',
        'page' => 'path/to/page',
        'form_id' => 'form_id',
        'data' => [
            'keyword1' => 'data.',
            'keyword2' => 'data.',
        ],
        'emphasis_keyword' => 'keyword1.DATA',
    ],
    'mp_template_msg' => [
        'appid' => 'official account app_id',
        'template_id' => 'template_id',
        'url' => 'web url',
        'miniprogram' => [
            'pagepath' => 'path/to/page'
        ],
        'data' => [
            'keyword1' => 'data.',
            'keyword2' => 'data.',
        ],
    ]
]);
```