### PR TITLE
 增加小程序动态消息支持 

### DIFF
--- a/src/MiniProgram/ActivityMessage/Client.php
+++ b/src/MiniProgram/ActivityMessage/Client.php
@@ -26,9 +26,9 @@ class Client extends BaseClient
     }
 
     /**
-     * @param $activityId
-     * @param int $state
-     * @param array $parameter
+     * @param string $activityId
+     * @param int    $state
+     * @param array  $parameter
      *
      * @return \Psr\Http\Message\ResponseInterface|\EasyWeChat\Kernel\Support\Collection|array|object|string
      *
@@ -36,7 +36,7 @@ class Client extends BaseClient
      */
     public function setUpdatableMsg($activityId, $state = 0, $parameter = [])
     {
-        if (!in_array($state, [0, 1])) {
+        if (!in_array($state, [0, 1], true)) {
             throw new InvalidArgumentException('"state" should be "0" or "1".');
         }
 
@@ -47,7 +47,7 @@ class Client extends BaseClient
             'target_state' => $state,
             'template_info' => ['parameter_list' => $parameterList]
         ];
-        return $this->httpPost('cgi-bin/message/wxopen/updatablemsg/send', $params);
+        return $this->httpPostJson('cgi-bin/message/wxopen/updatablemsg/send', $params);
     }
 
     /**
@@ -60,11 +60,11 @@ class Client extends BaseClient
         $parameterList = [];
 
         foreach ($data as $name => $value) {
-            if (!in_array($name, ['member_count', 'room_limit', 'path', 'version_type'])) {
+            if (!in_array($name, ['member_count', 'room_limit', 'path', 'version_type'], true)) {
                 continue;
             }
 
-            if ($name == 'version_type' && !in_array($value, ['develop', 'trial', 'release'])) {
+            if ($name == 'version_type' && !in_array($value, ['develop', 'trial', 'release'], true)) {
                 throw new InvalidArgumentException('Invalid value of attribute "version_type".');
             }
 

--- a/src/MiniProgram/ActivityMessage/Client.php
+++ b/src/MiniProgram/ActivityMessage/Client.php
@@ -27,39 +27,39 @@ class Client extends BaseClient
     /**
      * @param string $activityId
      * @param int    $state
-     * @param array  $parameter
+     * @param array  $params
      *
      * @return \Psr\Http\Message\ResponseInterface|\EasyWeChat\Kernel\Support\Collection|array|object|string
      *
      * @throws InvalidArgumentException
      */
-    public function updateMessage($activityId, $state = 0, $parameter = [])
+    public function updateMessage(string $activityId, int $state = 0, array $params = [])
     {
         if (!in_array($state, [0, 1], true)) {
             throw new InvalidArgumentException('"state" should be "0" or "1".');
         }
 
-        $parameterList = $this->formatParameterList($parameter);
+        $params = $this->formatParameters($params);
 
         $params = [
             'activity_id' => $activityId,
             'target_state' => $state,
-            'template_info' => ['parameter_list' => $parameterList],
+            'template_info' => ['parameter_list' => $params],
         ];
 
         return $this->httpPostJson('cgi-bin/message/wxopen/updatablemsg/send', $params);
     }
 
     /**
-     * @param $data
+     * @param array $params
      *
      * @return array
      */
-    protected function formatParameterList($data)
+    protected function formatParameters(array $params)
     {
-        $parameterList = [];
+        $formatted = [];
 
-        foreach ($data as $name => $value) {
+        foreach ($params as $name => $value) {
             if (!in_array($name, ['member_count', 'room_limit', 'path', 'version_type'], true)) {
                 continue;
             }
@@ -68,12 +68,12 @@ class Client extends BaseClient
                 throw new InvalidArgumentException('Invalid value of attribute "version_type".');
             }
 
-            $parameterList[] = [
+            $formatted[] = [
                 'name' => $name,
                 'value' => strval($value),
             ];
         }
 
-        return $parameterList;
+        return $formatted;
     }
 }

--- a/src/MiniProgram/ActivityMessage/Client.php
+++ b/src/MiniProgram/ActivityMessage/Client.php
@@ -16,7 +16,6 @@ use EasyWeChat\Kernel\Exceptions\InvalidArgumentException;
 
 class Client extends BaseClient
 {
-
     /**
      * @return \Psr\Http\Message\ResponseInterface|\EasyWeChat\Kernel\Support\Collection|array|object|string
      */
@@ -47,6 +46,7 @@ class Client extends BaseClient
             'target_state' => $state,
             'template_info' => ['parameter_list' => $parameterList],
         ];
+
         return $this->httpPostJson('cgi-bin/message/wxopen/updatablemsg/send', $params);
     }
 

--- a/src/MiniProgram/ActivityMessage/Client.php
+++ b/src/MiniProgram/ActivityMessage/Client.php
@@ -34,7 +34,7 @@ class Client extends BaseClient
      *
      * @throws InvalidArgumentException
      */
-    public function setUpdatableMsg($activityId, $state = 0, $parameter = [])
+    public function updateMessage($activityId, $state = 0, $parameter = [])
     {
         if (!in_array($state, [0, 1], true)) {
             throw new InvalidArgumentException('"state" should be "0" or "1".');
@@ -45,7 +45,7 @@ class Client extends BaseClient
         $params = [
             'activity_id' => $activityId,
             'target_state' => $state,
-            'template_info' => ['parameter_list' => $parameterList]
+            'template_info' => ['parameter_list' => $parameterList],
         ];
         return $this->httpPostJson('cgi-bin/message/wxopen/updatablemsg/send', $params);
     }
@@ -64,13 +64,13 @@ class Client extends BaseClient
                 continue;
             }
 
-            if ($name == 'version_type' && !in_array($value, ['develop', 'trial', 'release'], true)) {
+            if ('version_type' === $name && !in_array($value, ['develop', 'trial', 'release'], true)) {
                 throw new InvalidArgumentException('Invalid value of attribute "version_type".');
             }
 
             $parameterList[] = [
                 'name' => $name,
-                'value' => strval($value)
+                'value' => strval($value),
             ];
         }
 

--- a/src/MiniProgram/ActivityMessage/Client.php
+++ b/src/MiniProgram/ActivityMessage/Client.php
@@ -1,0 +1,79 @@
+<?php
+
+/*
+ * This file is part of the overtrue/wechat.
+ *
+ * (c) overtrue <i@overtrue.me>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace EasyWeChat\MiniProgram\ActivityMessage;
+
+use EasyWeChat\Kernel\BaseClient;
+use EasyWeChat\Kernel\Exceptions\InvalidArgumentException;
+
+class Client extends BaseClient
+{
+
+    /**
+     * @return \Psr\Http\Message\ResponseInterface|\EasyWeChat\Kernel\Support\Collection|array|object|string
+     */
+    public function createActivityId()
+    {
+        return $this->httpGet('cgi-bin/message/wxopen/activityid/create');
+    }
+
+    /**
+     * @param $activityId
+     * @param int $state
+     * @param array $parameter
+     *
+     * @return \Psr\Http\Message\ResponseInterface|\EasyWeChat\Kernel\Support\Collection|array|object|string
+     *
+     * @throws InvalidArgumentException
+     */
+    public function setUpdatableMsg($activityId, $state = 0, $parameter = [])
+    {
+        if (!in_array($state, [0, 1])) {
+            throw new InvalidArgumentException('"state" should be "0" or "1".');
+        }
+
+        $parameterList = $this->formatParameterList($parameter);
+
+        $params = [
+            'activity_id' => $activityId,
+            'target_state' => $state,
+            'template_info' => ['parameter_list' => $parameterList]
+        ];
+        return $this->httpPost('cgi-bin/message/wxopen/updatablemsg/send', $params);
+    }
+
+    /**
+     * @param $data
+     *
+     * @return array
+     */
+    protected function formatParameterList($data)
+    {
+        $parameterList = [];
+
+        foreach ($data as $name => $value) {
+            if (!in_array($name, ['member_count', 'room_limit', 'path', 'version_type'])) {
+                continue;
+            }
+
+            if ($name == 'version_type' && !in_array($value, ['develop', 'trial', 'release'])) {
+                throw new InvalidArgumentException('Invalid value of attribute "version_type".');
+            }
+
+            $parameterList[] = [
+                'name' => $name,
+                'value' => strval($value)
+            ];
+        }
+
+        return $parameterList;
+    }
+}

--- a/src/MiniProgram/ActivityMessage/ServiceProvider.php
+++ b/src/MiniProgram/ActivityMessage/ServiceProvider.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the overtrue/wechat.
+ *
+ * (c) overtrue <i@overtrue.me>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace EasyWeChat\MiniProgram\ActivityMessage;
+
+use Pimple\Container;
+use Pimple\ServiceProviderInterface;
+
+class ServiceProvider implements ServiceProviderInterface
+{
+    /**
+     * {@inheritdoc}.
+     */
+    public function register(Container $app)
+    {
+        $app['activity_message'] = function ($app) {
+            return new Client($app);
+        };
+    }
+}

--- a/src/MiniProgram/Application.php
+++ b/src/MiniProgram/Application.php
@@ -30,7 +30,8 @@ use EasyWeChat\Kernel\ServiceContainer;
  * @property \EasyWeChat\BasicService\Media\Client              $media
  * @property \EasyWeChat\BasicService\ContentSecurity\Client    $content_security
  * @property \EasyWeChat\MiniProgram\Plugin\Client              $plugin
- * @property \EasyWeChat\MiniProgram\UniformMessage\Client              $uniform_message
+ * @property \EasyWeChat\MiniProgram\UniformMessage\Client      $uniform_message
+ * @property \EasyWeChat\MiniProgram\ActivityMessage\Client     $activity_message
  */
 class Application extends ServiceContainer
 {
@@ -45,6 +46,7 @@ class Application extends ServiceContainer
         TemplateMessage\ServiceProvider::class,
         CustomerService\ServiceProvider::class,
         UniformMessage\ServiceProvider::class,
+        ActivityMessage\ServiceProvider::class,
         // Base services
         BasicService\Media\ServiceProvider::class,
         BasicService\ContentSecurity\ServiceProvider::class,


### PR DESCRIPTION
#1392 

### 微信文档：
[https://developers.weixin.qq.com/miniprogram/dev/framework/open-ability/share/updatable-message.html](https://developers.weixin.qq.com/miniprogram/dev/framework/open-ability/share/updatable-message.html)

### 用法

#### 创建动态消息 id

```php
$miniProgram->activity_message->createActivityId();
```

#### 修改动态消息状态

```php
$miniProgram->activity_message->setUpdatableMsg('activityId', 0, [
    'member_count' => 2,
    'room_limit' => 3,
    'path' => 'index/index',
    'version_type' => 'develop'
]);
```