### PR TITLE
feat(OpenPlatform): add clearQuota api to Client

### DIFF
--- a/src/OpenPlatform/Base/Client.php
+++ b/src/OpenPlatform/Base/Client.php
@@ -126,4 +126,20 @@ class Client extends BaseClient
 
         return $this->httpPostJson('cgi-bin/component/api_create_preauthcode', $params);
     }
+    
+    /**
+     * OpenPlatform Clear quota.
+     *
+     * @link https://open.weixin.qq.com/cgi-bin/showdocument?action=dir_list&t=resource/res_list&verify=1&id=open1419318587
+     *
+     * @return \Psr\Http\Message\ResponseInterface|\EasyWeChat\Kernel\Support\Collection|array|object|string
+     */
+    public function clearQuota()
+    {
+        $params = [
+            'component_appid' => $this->app['config']['app_id'],
+        ];
+        
+        return $this->httpPostJson('cgi-bin/component/clear_quota', $params);
+    }
 }

--- a/tests/OpenPlatform/Base/ClientTest.php
+++ b/tests/OpenPlatform/Base/ClientTest.php
@@ -115,4 +115,21 @@ class ClientTest extends TestCase
 
         $this->assertSame('mock-result', $result);
     }
+    
+    /**
+     * @uses Client::clearQuota()
+     */
+    public function testClearQuota()
+    {
+        $client = $this->mockApiClient(Client::class, [], new ServiceContainer(['app_id' => '123456']));
+        
+        $client->expects()
+            ->httpPostJson('cgi-bin/component/clear_quota', ['component_appid' => '123456'])
+            ->andReturn('mock-result')
+            ->once();
+        
+        $result = $client->clearQuota();
+        
+        $this->assertSame('mock-result', $result);
+    }
 }


### PR DESCRIPTION
## 问题描述

开放平台当日接口请求次数过多会触发 [错误代码](https://open.weixin.qq.com/cgi-bin/showdocument?action=dir_list&t=resource/res_list&verify=1&id=open1419318634) 45009
```
{
  "errcode":45009,
  "errmsg":"reach max api daily quota limit hint: [tc2RjA00381891]"
}
```

## 解决方案
根据 [开放平台 - 代公众号调用接口文档](https://open.weixin.qq.com/cgi-bin/showdocument?action=dir_list&t=resource/res_list&verify=1&id=open1419318587&token=&lang=) ，可请求 https://api.weixin.qq.com/cgi-bin/component/clear_quota 对开放平台当日请求限制进行清零（仅针对开放平台，与公众号清零接口不同）
PS: 并未找到提及限制触发次数的条件，与清零接口的调用限制的文档说明

## 使用方法
`$openPlatform->clearQuota();`