### PR TITLE
fix(kernel xml): sanitize invalid chars before xml parse

### DIFF
--- a/src/Kernel/Support/XML.php
+++ b/src/Kernel/Support/XML.php
@@ -29,7 +29,7 @@ class XML
     {
         $backup = libxml_disable_entity_loader(true);
 
-        $result = self::normalize(simplexml_load_string($xml, 'SimpleXMLElement', LIBXML_COMPACT | LIBXML_NOCDATA | LIBXML_NOBLANKS));
+        $result = self::normalize(simplexml_load_string(self::sanitize($xml), 'SimpleXMLElement', LIBXML_COMPACT | LIBXML_NOCDATA | LIBXML_NOBLANKS));
 
         libxml_disable_entity_loader($backup);
 
@@ -148,5 +148,19 @@ class XML
         }
 
         return $xml;
+    }
+
+    /**
+     * Delete invalid characters in XML
+     *
+     * @see https://www.w3.org/TR/2008/REC-xml-20081126/#charsets - XML charset range
+     * @see http://php.net/manual/en/regexp.reference.escape.php - escape in UTF-8 mode
+     *
+     * @param string $xml
+     * @return string
+     */
+    public static function sanitize($xml)
+    {
+        return preg_replace('/[^\x{9}\x{A}\x{D}\x{20}-\x{D7FF}\x{E000}-\x{FFFD}\x{10000}-\x{10FFFF}]+/u', '', $xml);
     }
 }


### PR DESCRIPTION
## 问题描述
之前有人提到 issue #989，偶尔在线上也发现无法解析 XML 的报错如下
```
production.ERROR: simplexml_load_string(): Entity: line 5: parser error : CData section not finished
ä {"exception":"[object] (ErrorException(code: 0): simplexml_load_string(): Entity: line 5: parser error : CData section not finished
ä at /project/vendor/overtrue/wechat/src/Kernel/Support/XML.php:32)
```
## 原因分析
经测试把 XML 内容解密发现有一个 **\x10** 字符，查 [XML文档](https://www.w3.org/TR/2008/REC-xml-20081126/#charsets) 表示这是一个非法字符，不能在 XML 中的任何位置出现
## 解决方案
1. 可以在 simplexml_load_string 调用前，使用  [libxml_use_internal_errors](https://php.net/manual/en/function.libxml-use-internal-errors.php)(true) 关闭抛错，这样遇到非法字符 simplexml_load_string 只会返回 false，而不是直接抛错
2. 在 \Kernel\Support\XML 中新增 sanitize 方法，在 simplexml_load_string 调用前对非法字符进行过滤