### PR TITLE
修复小程序模板消息多次发送错误

### DIFF
--- a/src/OfficialAccount/TemplateMessage/Client.php
+++ b/src/OfficialAccount/TemplateMessage/Client.php
@@ -210,6 +210,6 @@ class Client extends BaseClient
      */
     protected function restoreMessage()
     {
-        $this->message = (new ReflectionClass(__CLASS__))->getDefaultProperties()['message'];
+        $this->message = (new ReflectionClass(static::class))->getDefaultProperties()['message'];
     }
 }


### PR DESCRIPTION
小程序模板消息和统一模板消息均继承公众号模板消息发送类 `EasyWeChat\OfficialAccount\TemplateMessage\Client`，在 `send` 方法调用后会调用 `restoreMessage` 方法重置 `message` 属性，但是是以 `EasyWeChat\OfficialAccount\TemplateMessage\Client` 类作为标准重置，导致模板消息实例调用一次后再次调用 `message` 属性发生改变而报错。