### PR TITLE
CustomerService模块增加"下发客服输入状态"功能

### DIFF
--- a/src/OfficialAccount/CustomerService/Client.php
+++ b/src/OfficialAccount/CustomerService/Client.php
@@ -148,6 +148,36 @@ class Client extends BaseClient
     }
 
     /**
+     * Typing.
+     *
+     * @param string $openid
+     *
+     * @return mixed
+     */
+    public function typing(string $openid)
+    {
+        return $this->httpPostJson('cgi-bin/message/custom/typing', [
+            'touser' => $openid,
+            'command' => 'Typing',
+        ]);
+    }
+
+    /**
+     * Cancel typing.
+     *
+     * @param string $openid
+     *
+     * @return mixed
+     */
+    public function cancelTyping(string $openid)
+    {
+        return $this->httpPostJson('cgi-bin/message/custom/typing', [
+            'touser' => $openid,
+            'command' => 'CancelTyping',
+        ]);
+    }
+
+    /**
      * Get messages history.
      *
      * @param int $startTime

--- a/src/OfficialAccount/CustomerService/Client.php
+++ b/src/OfficialAccount/CustomerService/Client.php
@@ -148,7 +148,7 @@ class Client extends BaseClient
     }
 
     /**
-     * Typing.
+     * Show typing status.
      *
      * @param string $openid
      *
@@ -163,7 +163,7 @@ class Client extends BaseClient
     }
 
     /**
-     * Cancel typing.
+     * Hide typing status.
      *
      * @param string $openid
      *

--- a/src/OfficialAccount/CustomerService/Client.php
+++ b/src/OfficialAccount/CustomerService/Client.php
@@ -154,7 +154,7 @@ class Client extends BaseClient
      *
      * @return mixed
      */
-    public function typing(string $openid)
+    public function showTypingStatusToUser(string $openid)
     {
         return $this->httpPostJson('cgi-bin/message/custom/typing', [
             'touser' => $openid,
@@ -169,7 +169,7 @@ class Client extends BaseClient
      *
      * @return mixed
      */
-    public function cancelTyping(string $openid)
+    public function hideTypingStatusToUser(string $openid)
     {
         return $this->httpPostJson('cgi-bin/message/custom/typing', [
             'touser' => $openid,

--- a/tests/OfficialAccount/CustomerService/ClientTest.php
+++ b/tests/OfficialAccount/CustomerService/ClientTest.php
@@ -111,6 +111,30 @@ class ClientTest extends TestCase
         $this->assertSame('mock-result', $client->send(['foo' => 'bar']));
     }
 
+    public function testTyping()
+    {
+        $client = $this->mockApiClient(Client::class);
+
+        $client->expects()->httpPostJson('cgi-bin/message/custom/typing', [
+            'touser' => 'open-id',
+            'command' => 'Typing',
+        ])->andReturn('mock-result')->once();
+
+        $this->assertSame('mock-result', $client->typing('open-id'));
+    }
+
+    public function testCancelTyping()
+    {
+        $client = $this->mockApiClient(Client::class);
+
+        $client->expects()->httpPostJson('cgi-bin/message/custom/typing', [
+            'touser' => 'open-id',
+            'command' => 'CancelTyping',
+        ])->andReturn('mock-result')->once();
+
+        $this->assertSame('mock-result', $client->cancelTyping('open-id'));
+    }
+
     public function testMessages()
     {
         $client = $this->mockApiClient(Client::class);

--- a/tests/OfficialAccount/CustomerService/ClientTest.php
+++ b/tests/OfficialAccount/CustomerService/ClientTest.php
@@ -111,7 +111,7 @@ class ClientTest extends TestCase
         $this->assertSame('mock-result', $client->send(['foo' => 'bar']));
     }
 
-    public function testTyping()
+    public function testShowTypingStatusToUser()
     {
         $client = $this->mockApiClient(Client::class);
 
@@ -120,10 +120,10 @@ class ClientTest extends TestCase
             'command' => 'Typing',
         ])->andReturn('mock-result')->once();
 
-        $this->assertSame('mock-result', $client->typing('open-id'));
+        $this->assertSame('mock-result', $client->showTypingStatusToUser('open-id'));
     }
 
-    public function testCancelTyping()
+    public function testHideTypingStatusToUser()
     {
         $client = $this->mockApiClient(Client::class);
 
@@ -132,7 +132,7 @@ class ClientTest extends TestCase
             'command' => 'CancelTyping',
         ])->andReturn('mock-result')->once();
 
-        $this->assertSame('mock-result', $client->cancelTyping('open-id'));
+        $this->assertSame('mock-result', $client->hideTypingStatusToUser('open-id'));
     }
 
     public function testMessages()


### PR DESCRIPTION
下发客服当前输入状态给用户(公众号、小程序皆可使用)
```
// 对用户下发"正在输入"状态
$app->customer_service-> showTypingStatusToUser($openid);

// 取消对用户的"正在输入"状态
$app->customer_service-> hideTypingStatusToUser($openid);
```
参考链接：
https://developers.weixin.qq.com/miniprogram/dev/api-backend/customerTyping.html
https://mp.weixin.qq.com/wiki?t=resource/res_main&id=mp1421140547