### PR TITLE
4.1 (#1497)

### DIFF
--- a/src/OfficialAccount/CustomerService/Client.php
+++ b/src/OfficialAccount/CustomerService/Client.php
@@ -148,6 +148,36 @@ class Client extends BaseClient
     }
 
     /**
+     * Show typing status.
+     *
+     * @param string $openid
+     *
+     * @return mixed
+     */
+    public function showTypingStatusToUser(string $openid)
+    {
+        return $this->httpPostJson('cgi-bin/message/custom/typing', [
+            'touser' => $openid,
+            'command' => 'Typing',
+        ]);
+    }
+
+    /**
+     * Hide typing status.
+     *
+     * @param string $openid
+     *
+     * @return mixed
+     */
+    public function hideTypingStatusToUser(string $openid)
+    {
+        return $this->httpPostJson('cgi-bin/message/custom/typing', [
+            'touser' => $openid,
+            'command' => 'CancelTyping',
+        ]);
+    }
+
+    /**
      * Get messages history.
      *
      * @param int $startTime

--- a/src/OpenPlatform/Authorizer/MiniProgram/Setting/Client.php
+++ b/src/OpenPlatform/Authorizer/MiniProgram/Setting/Client.php
@@ -122,4 +122,79 @@ class Client extends BaseClient
         return $this->httpPostJson(
             'cgi-bin/wxverify/checkwxverifynickname', $params);
     }
+
+    /**
+     * 查询小程序是否可被搜索.
+     *
+     * @return array|\EasyWeChat\Kernel\Support\Collection|object|\Psr\Http\Message\ResponseInterface|string
+     */
+    public function getSearchStatus()
+    {
+        return $this->httpGet('wxa/getwxasearchstatus');
+    }
+
+    /**
+     * 设置小程序可被搜素.
+     *
+     * @return array|\EasyWeChat\Kernel\Support\Collection|object|\Psr\Http\Message\ResponseInterface|string
+     */
+    public function setSearchable()
+    {
+        return $this->httpPostJson('wxa/changewxasearchstatus', [
+            'status' => 0,
+        ]);
+    }
+
+    /**
+     * 设置小程序不可被搜素.
+     *
+     * @return array|\EasyWeChat\Kernel\Support\Collection|object|\Psr\Http\Message\ResponseInterface|string
+     */
+    public function setUnsearchable()
+    {
+        return $this->httpPostJson('wxa/changewxasearchstatus', [
+            'status' => 1,
+        ]);
+    }
+
+    /**
+     * 获取展示的公众号信息.
+     *
+     * @return array|\EasyWeChat\Kernel\Support\Collection|object|\Psr\Http\Message\ResponseInterface|string
+     */
+    public function getDisplayedOfficialAccount()
+    {
+        return $this->httpGet('wxa/getshowwxaitem');
+    }
+
+    /**
+     * 设置展示的公众号.
+     *
+     * @param string|bool $appid
+     *
+     * @return array|\EasyWeChat\Kernel\Support\Collection|object|\Psr\Http\Message\ResponseInterface|string
+     */
+    public function setDisplayedOfficialAccount($appid)
+    {
+        return $this->httpPostJson('wxa/updateshowwxaitem', [
+            'appid' => $appid ?: null,
+            'wxa_subscribe_biz_flag' => $appid ? 1 : 0,
+        ]);
+    }
+
+    /**
+     * 获取可以用来设置的公众号列表.
+     *
+     * @param int $page
+     * @param int $num
+     *
+     * @return array|\EasyWeChat\Kernel\Support\Collection|object|\Psr\Http\Message\ResponseInterface|string
+     */
+    public function getDisplayableOfficialAccounts(int $page, int $num)
+    {
+        return $this->httpGet('wxa/getwxamplinkforshow', [
+            'page' => $page,
+            'num' => $num,
+        ]);
+    }
 }

--- a/tests/OfficialAccount/CustomerService/ClientTest.php
+++ b/tests/OfficialAccount/CustomerService/ClientTest.php
@@ -111,6 +111,30 @@ class ClientTest extends TestCase
         $this->assertSame('mock-result', $client->send(['foo' => 'bar']));
     }
 
+    public function testShowTypingStatusToUser()
+    {
+        $client = $this->mockApiClient(Client::class);
+
+        $client->expects()->httpPostJson('cgi-bin/message/custom/typing', [
+            'touser' => 'open-id',
+            'command' => 'Typing',
+        ])->andReturn('mock-result')->once();
+
+        $this->assertSame('mock-result', $client->showTypingStatusToUser('open-id'));
+    }
+
+    public function testHideTypingStatusToUser()
+    {
+        $client = $this->mockApiClient(Client::class);
+
+        $client->expects()->httpPostJson('cgi-bin/message/custom/typing', [
+            'touser' => 'open-id',
+            'command' => 'CancelTyping',
+        ])->andReturn('mock-result')->once();
+
+        $this->assertSame('mock-result', $client->hideTypingStatusToUser('open-id'));
+    }
+
     public function testMessages()
     {
         $client = $this->mockApiClient(Client::class);

--- a/tests/OpenPlatform/Authorizer/MiniProgram/Setting/ClientTest.php
+++ b/tests/OpenPlatform/Authorizer/MiniProgram/Setting/ClientTest.php
@@ -113,4 +113,59 @@ class ClientTest extends TestCase
         $this->assertSame(
             'mock-result', $this->client->isAvailableNickname('name'));
     }
+
+    public function testGetSearchStatus()
+    {
+        $this->client->expects()->httpGet('wxa/getwxasearchstatus')->andReturn('mock-result')->once();
+        $this->assertSame('mock-result', $this->client->getSearchStatus());
+    }
+
+    public function testSetSearchable()
+    {
+        $this->client->expects()->httpPostJson('wxa/changewxasearchstatus', [
+            'status' => 0,
+        ])->andReturn('mock-result')->once();
+        $this->assertSame('mock-result', $this->client->setSearchable());
+    }
+
+    public function testSetUnsearchable()
+    {
+        $this->client->expects()->httpPostJson('wxa/changewxasearchstatus', [
+            'status' => 1,
+        ])->andReturn('mock-result')->once();
+        $this->assertSame('mock-result', $this->client->setUnsearchable());
+    }
+
+    public function testGetDisplayedOfficialAccount()
+    {
+        $this->client->expects()->httpGet('wxa/getshowwxaitem')->andReturn('mock-result')->once();
+        $this->assertSame('mock-result', $this->client->getDisplayedOfficialAccount());
+    }
+
+    public function testSetDisplayedOfficialAccount()
+    {
+        $this->client->expects()->httpPostJson('wxa/updateshowwxaitem', [
+            'appid' => 'app-id',
+            'wxa_subscribe_biz_flag' => 1,
+        ])->andReturn('mock-result')->once();
+        $this->assertSame('mock-result', $this->client->setDisplayedOfficialAccount('app-id'));
+    }
+
+    public function testSetOfficialAccountCantNotDisplayed()
+    {
+        $this->client->expects()->httpPostJson('wxa/updateshowwxaitem', [
+            'appid' => null,
+            'wxa_subscribe_biz_flag' => 0,
+        ])->andReturn('mock-result')->once();
+        $this->assertSame('mock-result', $this->client->setDisplayedOfficialAccount(false));
+    }
+
+    public function testGetDisplayableOfficialAccounts()
+    {
+        $this->client->expects()->httpGet('wxa/getwxamplinkforshow', [
+            'page' => 1,
+            'num' => 10,
+        ])->andReturn('mock-result')->once();
+        $this->assertSame('mock-result', $this->client->getDisplayableOfficialAccounts(1, 10));
+    }
 }


### PR DESCRIPTION
* CustomerService模块增加"下发客服输入状态"功能 (#1495)

* CustomerService模块增加"下发客服输入状态"功能

* 修改方法命名

* 完善注释

* 开放平台-小程序隐私设置&公众号关注组件 (#1479)

* 开放平台-小程序的公众号关注组件，以及小程序的隐私设置

* fixed #1479

* 调整 API

* 开放平台-小程序的公众号关注组件，以及小程序的隐私设置

* fixed #1479

* 调整 API

* fixed

* fixed

* 修改注释