### PR TITLE
Update tests files

### DIFF
--- a/tests/BasicService/ContentSecurity/ClientTest.php
+++ b/tests/BasicService/ContentSecurity/ClientTest.php
@@ -23,7 +23,7 @@ class ClientTest extends TestCase
 
         $client->expects()->httpPostJson('msg_sec_check', [
             'content' => 'foo',
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->checkText('foo'));
     }
@@ -37,7 +37,7 @@ class ClientTest extends TestCase
 
         $client->expects()->httpUpload('img_sec_check', [
             'media' => $imagePath,
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->checkImage($imagePath));
     }

--- a/tests/BasicService/ContentSecurity/ClientTest.php
+++ b/tests/BasicService/ContentSecurity/ClientTest.php
@@ -19,7 +19,7 @@ class ClientTest extends TestCase
     public function testCheckText()
     {
         $client = $this->mockApiClient(Client::class, 'checkText')->shouldAllowMockingProtectedMethods();
-        $client->shouldDeferMissing();
+        $client->makePartial();
 
         $client->expects()->httpPostJson('msg_sec_check', [
             'content' => 'foo',
@@ -31,7 +31,7 @@ class ClientTest extends TestCase
     public function testCheckImage()
     {
         $client = $this->mockApiClient(Client::class, 'checkImage')->shouldAllowMockingProtectedMethods();
-        $client->shouldDeferMissing();
+        $client->makePartial();
 
         $imagePath = 'foo';
 

--- a/tests/BasicService/Jssdk/ClientTest.php
+++ b/tests/BasicService/Jssdk/ClientTest.php
@@ -50,7 +50,7 @@ class ClientTest extends TestCase
     public function testGetConfigArray()
     {
         $client = $this->mockApiClient(Client::class, 'buildConfig');
-        $client->expects()->buildConfig(['api1', 'api2'], true, true, false)->andReturn('mock-result')->once();
+        $client->expects()->buildConfig(['api1', 'api2'], true, true, false)->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->getConfigArray(['api1', 'api2'], true, true));
     }
@@ -71,7 +71,7 @@ class ClientTest extends TestCase
         $response = new \EasyWeChat\Kernel\Http\Response(200, [], json_encode($ticket));
 
         // no refresh and cached
-        $cache->expects()->has($cacheKey)->once()->andReturn(true);
+        $cache->expects()->has($cacheKey)->andReturn(true);
         $cache->expects()->get($cacheKey)->andReturn($ticket);
 
         $this->assertSame($ticket, $client->getTicket());
@@ -80,7 +80,7 @@ class ClientTest extends TestCase
         $cache->expects()->has($cacheKey)->twice()->andReturns(false, true);
         $cache->expects()->get($cacheKey)->never();
         $cache->expects()->set($cacheKey, $ticket, $ticket['expires_in'] - 500);
-        $client->expects()->requestRaw('https://api.weixin.qq.com/cgi-bin/ticket/getticket', 'GET', ['query' => ['type' => 'jsapi']])->andReturn($response)->once();
+        $client->expects()->requestRaw('https://api.weixin.qq.com/cgi-bin/ticket/getticket', 'GET', ['query' => ['type' => 'jsapi']])->andReturn($response);
 
         $this->assertSame($ticket, $client->getTicket());
 
@@ -88,7 +88,7 @@ class ClientTest extends TestCase
         $cache->expects()->has($cacheKey)->andReturn(true);
         $cache->expects()->get($cacheKey)->never();
         $cache->expects()->set($cacheKey, $ticket, $ticket['expires_in'] - 500);
-        $client->expects()->requestRaw('https://api.weixin.qq.com/cgi-bin/ticket/getticket', 'GET', ['query' => ['type' => 'jsapi']])->andReturn($response)->once();
+        $client->expects()->requestRaw('https://api.weixin.qq.com/cgi-bin/ticket/getticket', 'GET', ['query' => ['type' => 'jsapi']])->andReturn($response);
 
         $this->assertSame($ticket, $client->getTicket(true));
 
@@ -96,9 +96,9 @@ class ClientTest extends TestCase
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Failed to cache jssdk ticket.');
 
-        $cache->expects()->set($cacheKey, $ticket, $ticket['expires_in'] - 500)->once();
-        $cache->expects()->has($cacheKey)->once()->andReturn(false);
-        $client->expects()->requestRaw('https://api.weixin.qq.com/cgi-bin/ticket/getticket', 'GET', ['query' => ['type' => 'jsapi']])->andReturn($response)->once();
+        $cache->expects()->set($cacheKey, $ticket, $ticket['expires_in'] - 500);
+        $cache->expects()->has($cacheKey)->andReturn(false);
+        $client->expects()->requestRaw('https://api.weixin.qq.com/cgi-bin/ticket/getticket', 'GET', ['query' => ['type' => 'jsapi']])->andReturn($response);
 
         $client->getTicket(true);
     }

--- a/tests/BasicService/Media/ClientTest.php
+++ b/tests/BasicService/Media/ClientTest.php
@@ -57,7 +57,7 @@ class ClientTest extends TestCase
         $client = $this->mockApiClient(Client::class, ['httpUpload']);
 
         $path = STUBS_ROOT.'/files/image.jpg';
-        $client->expects()->httpUpload('media/upload', ['media' => $path], ['type' => 'image'])->andReturn('mock-response')->once();
+        $client->expects()->httpUpload('media/upload', ['media' => $path], ['type' => 'image'])->andReturn('mock-response');
 
         $client->upload('image', $path);
 
@@ -85,14 +85,14 @@ class ClientTest extends TestCase
         $client->allows()->uploadVideo($path)->andReturn('mock-response');
 
         // no media_id
-        $client->expects()->detectAndCastResponseToType('mock-response', 'array')->andReturn(['foo' => 'bar'])->once();
+        $client->expects()->detectAndCastResponseToType('mock-response', 'array')->andReturn(['foo' => 'bar']);
         $client->shouldNotReceive('createVideoForBroadcasting');
 
         $client->uploadVideoForBroadcasting($path, 'title', 'description');
 
         // return media_id
-        $client->expects()->detectAndCastResponseToType('mock-response', 'array')->andReturn(['media_id' => 'mock-media-id'])->once();
-        $client->expects()->createVideoForBroadcasting('mock-media-id', 'title', 'description')->once();
+        $client->expects()->detectAndCastResponseToType('mock-response', 'array')->andReturn(['media_id' => 'mock-media-id']);
+        $client->expects()->createVideoForBroadcasting('mock-media-id', 'title', 'description');
 
         $client->uploadVideoForBroadcasting($path, 'title', 'description');
     }
@@ -107,7 +107,7 @@ class ClientTest extends TestCase
             'media_id' => $mediaId,
             'title' => $title,
             'description' => $description,
-        ])->andReturn('mock-response')->once();
+        ])->andReturn('mock-response');
 
         $this->assertSame('mock-response', $client->createVideoForBroadcasting($mediaId, $title, $description));
     }
@@ -123,7 +123,7 @@ class ClientTest extends TestCase
             'query' => [
                 'media_id' => $mediaId,
             ],
-        ])->andReturn($imageResponse)->once();
+        ])->andReturn($imageResponse);
 
         $this->assertSame(['error' => 'invalid media id hits.'], $client->get($mediaId));
 
@@ -133,7 +133,7 @@ class ClientTest extends TestCase
             'query' => [
                 'media_id' => $mediaId,
             ],
-        ])->andReturn($imageResponse)->once();
+        ])->andReturn($imageResponse);
 
         $this->assertInstanceOf(StreamResponse::class, $client->get($mediaId));
     }
@@ -149,7 +149,7 @@ class ClientTest extends TestCase
             'query' => [
                 'media_id' => $mediaId,
             ],
-        ])->andReturn($imageResponse)->once();
+        ])->andReturn($imageResponse);
 
         $this->assertSame(['error' => 'invalid media id hits.'], $client->getJssdkMedia($mediaId));
 
@@ -159,7 +159,7 @@ class ClientTest extends TestCase
             'query' => [
                 'media_id' => $mediaId,
             ],
-        ])->andReturn($imageResponse)->once();
+        ])->andReturn($imageResponse);
 
         $this->assertInstanceOf(StreamResponse::class, $client->getJssdkMedia($mediaId));
     }

--- a/tests/BasicService/QrCode/ClientTest.php
+++ b/tests/BasicService/QrCode/ClientTest.php
@@ -59,7 +59,7 @@ class ClientTest extends TestCase
     public function testCreate()
     {
         $client = $this->mockApiClient(Client::class, 'create')->shouldAllowMockingProtectedMethods();
-        $client->shouldDeferMissing();
+        $client->makePartial();
 
         // temporary = true, expireSeconds = null
         $client->expects()->httpPostJson('qrcode/create', [

--- a/tests/BasicService/QrCode/ClientTest.php
+++ b/tests/BasicService/QrCode/ClientTest.php
@@ -23,13 +23,13 @@ class ClientTest extends TestCase
         // int
         $client->expects()->create(Client::SCENE_QR_FOREVER, [
             'scene_id' => 99999,
-        ], false)->andReturn('mock-result')->once();
+        ], false)->andReturn('mock-result');
         $this->assertSame('mock-result', $client->forever(99999));
 
         // string
         $client->expects()->create(Client::SCENE_QR_FOREVER_STR, [
             'scene_str' => 'foo',
-        ], false)->andReturn('mock-result')->once();
+        ], false)->andReturn('mock-result');
         $this->assertSame('mock-result', $client->forever('foo'));
     }
 
@@ -40,13 +40,13 @@ class ClientTest extends TestCase
         // int
         $client->expects()->create(Client::SCENE_QR_TEMPORARY, [
             'scene_id' => 99999,
-        ], true, null)->andReturn('mock-result')->once();
+        ], true, null)->andReturn('mock-result');
         $this->assertSame('mock-result', $client->temporary(99999));
 
         // string
         $client->expects()->create(Client::SCENE_QR_TEMPORARY_STR, [
             'scene_str' => 'foo',
-        ], true, 7200)->andReturn('mock-result')->once();
+        ], true, 7200)->andReturn('mock-result');
         $this->assertSame('mock-result', $client->temporary('foo', 7200));
     }
 
@@ -66,7 +66,7 @@ class ClientTest extends TestCase
             'action_name' => Client::SCENE_QR_CARD,
             'action_info' => ['scene' => ['foo' => 'bar']],
             'expire_seconds' => 7 * Client::DAY,
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->create(Client::SCENE_QR_CARD, ['foo' => 'bar']));
 
@@ -74,7 +74,7 @@ class ClientTest extends TestCase
         $client->expects()->httpPostJson('qrcode/create', [
             'action_name' => Client::SCENE_QR_FOREVER,
             'action_info' => ['scene' => ['foo' => 'bar']],
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->create(Client::SCENE_QR_FOREVER, ['foo' => 'bar'], false));
 
@@ -83,7 +83,7 @@ class ClientTest extends TestCase
             'action_name' => Client::SCENE_QR_TEMPORARY_STR,
             'action_info' => ['scene' => ['foo' => 'bar']],
             'expire_seconds' => 500,
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->create(Client::SCENE_QR_TEMPORARY_STR, ['foo' => 'bar'], true, 500));
     }

--- a/tests/BasicService/Url/ClientTest.php
+++ b/tests/BasicService/Url/ClientTest.php
@@ -23,7 +23,7 @@ class ClientTest extends TestCase
         $client->expects()->httpPostJson('cgi-bin/shorturl', [
             'action' => 'long2short',
             'long_url' => $url,
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->shorten($url));
     }

--- a/tests/Kernel/AccessTokenTest.php
+++ b/tests/Kernel/AccessTokenTest.php
@@ -70,15 +70,15 @@ class AccessTokenTest extends TestCase
         // no refresh and no cached
         $cache->expects()->has('mock-cache-key')->andReturn(false);
         $cache->expects()->get('mock-cache-key')->never();
-        $token->expects()->requestToken($credentials, true)->andReturn($tokenResult)->once();
-        $token->expects()->setToken($tokenResult['access_token'], $tokenResult['expires_in'])->once();
+        $token->expects()->requestToken($credentials, true)->andReturn($tokenResult);
+        $token->expects()->setToken($tokenResult['access_token'], $tokenResult['expires_in']);
 
         $this->assertSame($tokenResult, $token->getToken());
 
         // with refresh and cached
         $cache->expects()->has('mock-cache-key')->never();
-        $token->expects()->requestToken($credentials, true)->andReturn($tokenResult)->once();
-        $token->expects()->setToken($tokenResult['access_token'], $tokenResult['expires_in'])->once();
+        $token->expects()->requestToken($credentials, true)->andReturn($tokenResult);
+        $token->expects()->setToken($tokenResult['access_token'], $tokenResult['expires_in']);
 
         $this->assertSame($tokenResult, $token->getRefreshedToken());
     }
@@ -96,7 +96,7 @@ class AccessTokenTest extends TestCase
         $cache->expects()->set('mock-cache-key', [
             'access_token' => 'mock-token',
             'expires_in' => 7200,
-        ], 7200 - 500)->once()->andReturn(true);
+        ], 7200 - 500)->andReturn(true);
         $result = $token->setToken('mock-token');
         $this->assertSame($token, $result);
 
@@ -105,7 +105,7 @@ class AccessTokenTest extends TestCase
         $cache->expects()->set('mock-cache-key', [
             'access_token' => 'mock-token',
             'expires_in' => 7000,
-        ], 7000 - 500)->once()->andReturn(true);
+        ], 7000 - 500)->andReturn(true);
         $result = $token->setToken('mock-token', 7000);
         $this->assertSame($token, $result);
 
@@ -115,7 +115,7 @@ class AccessTokenTest extends TestCase
         $cache->expects()->set('mock-cache-key', [
             'access_token' => 'mock-token',
             'expires_in' => 7000,
-        ], 7000 - 500)->once()->andReturn(false);
+        ], 7000 - 500)->andReturn(false);
         $token->setToken('mock-token', 7000);
     }
 
@@ -124,7 +124,7 @@ class AccessTokenTest extends TestCase
         $app = \Mockery::mock(ServiceContainer::class);
         $token = \Mockery::mock(AccessToken::class.'[getToken]', [$app])
             ->shouldAllowMockingProtectedMethods();
-        $token->expects()->getToken(true)->once();
+        $token->expects()->getToken(true);
 
         $result = $token->refresh();
 
@@ -157,7 +157,7 @@ class AccessTokenTest extends TestCase
 
         // erred
         $response = new Response(200, [], '{"error_msg":"mock-error-message"}');
-        $token->expects()->sendRequest($credentials)->andReturn($response)->once();
+        $token->expects()->sendRequest($credentials)->andReturn($response);
 
         try {
             $token->requestToken($credentials);
@@ -196,10 +196,10 @@ class AccessTokenTest extends TestCase
         $app['http_client'] = \Mockery::mock(Client::class);
 
         $token->expects()->sendRequest($credentials)->passthru();
-        $token->expects()->getEndpoint()->andReturn('/auth/get-token')->once();
-        $token->expects()->setHttpClient($app['http_client'])->andReturnSelf()->once();
+        $token->expects()->getEndpoint()->andReturn('/auth/get-token');
+        $token->expects()->setHttpClient($app['http_client'])->andReturnSelf();
         $token->expects()->request('/auth/get-token', 'GET', ['query' => $credentials])
-                        ->andReturn(new Response(200, [], 'mock-response'))->once();
+                        ->andReturn(new Response(200, [], 'mock-response'));
 
         $response = $token->sendRequest($credentials);
         $this->assertSame('mock-response', $response->getBody()->getContents());
@@ -213,10 +213,10 @@ class AccessTokenTest extends TestCase
         ];
 
         $token->expects()->sendRequest($credentials)->passthru();
-        $token->expects()->getEndpoint()->andReturn('/auth/get-token')->once();
-        $token->expects()->setHttpClient($app['http_client'])->andReturnSelf()->once();
+        $token->expects()->getEndpoint()->andReturn('/auth/get-token');
+        $token->expects()->setHttpClient($app['http_client'])->andReturnSelf();
         $token->expects()->request('/auth/get-token', 'post', ['json' => $credentials])
-            ->andReturn(new Response(200, [], 'mock-response'))->once();
+            ->andReturn(new Response(200, [], 'mock-response'));
 
         $response = $token->sendRequest($credentials);
         $this->assertSame('mock-response', $response->getBody()->getContents());
@@ -243,7 +243,7 @@ class AccessTokenTest extends TestCase
         $token = \Mockery::mock(AccessToken::class.'[getToken,getQuery]', [$app])
             ->shouldAllowMockingProtectedMethods();
 
-        $token->expects()->getToken()->andReturn(['access_token' => 'mock-token'])->once();
+        $token->expects()->getToken()->andReturn(['access_token' => 'mock-token']);
         $token->expects()->getQuery()->passthru();
 
         $this->assertSame(['access_token' => 'mock-token'], $token->getQuery());
@@ -252,7 +252,7 @@ class AccessTokenTest extends TestCase
         $token = \Mockery::mock(DummyAccessTokenForTest::class.'[getToken,getQuery]', [$app])
             ->shouldAllowMockingProtectedMethods();
 
-        $token->expects()->getToken()->andReturn(['foo' => 'mock-token'])->once();
+        $token->expects()->getToken()->andReturn(['foo' => 'mock-token']);
         $token->expects()->getQuery()->passthru();
 
         $this->assertSame(['foo' => 'mock-token'], $token->getQuery());

--- a/tests/Kernel/BaseClientTest.php
+++ b/tests/Kernel/BaseClientTest.php
@@ -38,7 +38,7 @@ class BaseClientTest extends TestCase
         $client = $this->makeClient('request');
         $url = 'http://easywechat.org';
         $query = ['foo' => 'bar'];
-        $client->expects()->request($url, 'GET', ['query' => $query])->andReturn('mock-result')->once();
+        $client->expects()->request($url, 'GET', ['query' => $query])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->httpGet($url, $query));
     }
 
@@ -48,7 +48,7 @@ class BaseClientTest extends TestCase
         $url = 'http://easywechat.org';
 
         $data = ['foo' => 'bar'];
-        $client->expects()->request($url, 'POST', ['form_params' => $data])->andReturn('mock-result')->once();
+        $client->expects()->request($url, 'POST', ['form_params' => $data])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->httpPost($url, $data));
     }
 
@@ -59,7 +59,7 @@ class BaseClientTest extends TestCase
 
         $data = ['foo' => 'bar'];
         $query = ['appid' => 1234];
-        $client->expects()->request($url, 'POST', ['query' => $query, 'json' => $data])->andReturn('mock-result')->once();
+        $client->expects()->request($url, 'POST', ['query' => $query, 'json' => $data])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->httpPostJson($url, $data, $query));
     }
 
@@ -83,7 +83,7 @@ class BaseClientTest extends TestCase
             $this->assertInternalType('resource', $params['multipart'][0]['contents']);
 
             return true;
-        }))->andReturn('mock-result')->once();
+        }))->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->httpUpload($url, $files, $form, $query));
     }
@@ -109,14 +109,14 @@ class BaseClientTest extends TestCase
             ->shouldAllowMockingProtectedMethods();
 
         // default value
-        $client->expects()->registerHttpMiddlewares()->once();
+        $client->expects()->registerHttpMiddlewares();
         $client->expects()->performRequest($url, 'GET', [])->andReturn(new Response(200, [], '{"mock":"result"}'));
         $this->assertSame(['mock' => 'result'], $client->request($url));
 
         // return raw with custom arguments
         $options = ['foo' => 'bar'];
         $response = new Response(200, [], '{"mock":"result"}');
-        $client->expects()->registerHttpMiddlewares()->once();
+        $client->expects()->registerHttpMiddlewares();
         $client->expects()->performRequest($url, 'POST', $options)->andReturn($response);
         $this->assertSame($response, $client->request($url, 'POST', $options, true));
     }
@@ -126,7 +126,7 @@ class BaseClientTest extends TestCase
         $url = 'http://easywechat.org';
         $response = new Response(200, [], '{"mock":"result"}');
         $client = $this->makeClient('request');
-        $client->expects()->request($url, 'GET', [], true)->andReturn($response)->once();
+        $client->expects()->request($url, 'GET', [], true)->andReturn($response);
 
         $this->assertInstanceOf(Response::class, $client->requestRaw($url));
     }
@@ -162,12 +162,12 @@ class BaseClientTest extends TestCase
         $accessTokenMiddleware = function () {
             return 'access_token';
         };
-        $client->expects()->retryMiddleware()->andReturn($retryMiddleware)->once();
-        $client->expects()->accessTokenMiddleware()->andReturn($accessTokenMiddleware)->once();
-        $client->expects()->logMiddleware()->andReturn($logMiddleware)->once();
-        $client->expects()->pushMiddleware($retryMiddleware, 'retry')->once();
-        $client->expects()->pushMiddleware($accessTokenMiddleware, 'access_token')->once();
-        $client->expects()->pushMiddleware($logMiddleware, 'log')->once();
+        $client->expects()->retryMiddleware()->andReturn($retryMiddleware);
+        $client->expects()->accessTokenMiddleware()->andReturn($accessTokenMiddleware);
+        $client->expects()->logMiddleware()->andReturn($logMiddleware);
+        $client->expects()->pushMiddleware($retryMiddleware, 'retry');
+        $client->expects()->pushMiddleware($accessTokenMiddleware, 'access_token');
+        $client->expects()->pushMiddleware($logMiddleware, 'log');
 
         $client->registerHttpMiddlewares();
     }
@@ -184,7 +184,7 @@ class BaseClientTest extends TestCase
 
         $request = new Request('GET', 'http://easywechat.com');
         $options = ['foo' => 'bar'];
-        $accessToken->expects()->applyToRequest($request, $options)->andReturn($request)->once();
+        $accessToken->expects()->applyToRequest($request, $options)->andReturn($request);
 
         $middleware = $func(function ($request, $options) {
             return compact('request', 'options');
@@ -223,8 +223,8 @@ class BaseClientTest extends TestCase
         $func = $client->retryMiddleware();
 
         // default once with right response
-        $logger->expects()->debug('Retrying with refreshed access token.')->once();
-        $accessToken->expects()->refresh()->once();
+        $logger->expects()->debug('Retrying with refreshed access token.');
+        $accessToken->expects()->refresh();
         $handler = new MockHandler([
             new Response(200, [], '{"errcode":40001}'),
             new Response(200, [], '{"success": true}'),
@@ -238,8 +238,8 @@ class BaseClientTest extends TestCase
         $this->assertSame('{"success": true}', $response->getBody()->getContents());
 
         // default once with error response
-        $logger->expects()->debug('Retrying with refreshed access token.')->once();
-        $accessToken->expects()->refresh()->once();
+        $logger->expects()->debug('Retrying with refreshed access token.');
+        $accessToken->expects()->refresh();
         $handler = new MockHandler([
             new Response(200, [], '{"errcode":40001}'),
             new Response(200, [], '{"errcode":42001}'),

--- a/tests/Kernel/BaseClientTest.php
+++ b/tests/Kernel/BaseClientTest.php
@@ -152,7 +152,7 @@ class BaseClientTest extends TestCase
     {
         $client = $this->makeClient(['retryMiddleware', 'accessTokenMiddleware', 'logMiddleware', 'pushMiddleware'])
             ->shouldAllowMockingProtectedMethods()
-            ->shouldDeferMissing();
+            ->makePartial();
         $retryMiddleware = function () {
             return 'retry';
         };
@@ -178,7 +178,7 @@ class BaseClientTest extends TestCase
         $accessToken = \Mockery::mock(AccessToken::class.'[applyToRequest]', [$app]);
         $client = $this->makeClient(['accessTokenMiddleware'], $app, $accessToken)
             ->shouldAllowMockingProtectedMethods()
-            ->shouldDeferMissing();
+            ->makePartial();
 
         $func = $client->accessTokenMiddleware();
 
@@ -205,7 +205,7 @@ class BaseClientTest extends TestCase
         $app['logger'] = new Logger('logger');
         $client = $this->makeClient(['accessTokenMiddleware'], $app)
             ->shouldAllowMockingProtectedMethods()
-            ->shouldDeferMissing();
+            ->makePartial();
 
         $this->assertInstanceOf('Closure', $client->logMiddleware());
     }
@@ -218,7 +218,7 @@ class BaseClientTest extends TestCase
         $accessToken = \Mockery::mock(AccessToken::class, [$app]);
         $client = $this->makeClient(['retryMiddleware'], $app, $accessToken)
             ->shouldAllowMockingProtectedMethods()
-            ->shouldDeferMissing();
+            ->makePartial();
 
         $func = $client->retryMiddleware();
 

--- a/tests/Kernel/Http/StreamResponseTest.php
+++ b/tests/Kernel/Http/StreamResponseTest.php
@@ -76,8 +76,8 @@ class StreamResponseTest extends TestCase
     public function testSaveAs()
     {
         $response = Mockery::mock(StreamResponse::class.'[save]');
-        $response->expects()->save('dir', 'filename', true)->andReturn('filename.png')->once();
-        $response->expects()->save('dir', 'filename', false)->andReturn('filename')->once();
+        $response->expects()->save('dir', 'filename', true)->andReturn('filename.png');
+        $response->expects()->save('dir', 'filename', false)->andReturn('filename');
 
         $this->assertSame('filename.png', $response->saveAs('dir', 'filename'));
 

--- a/tests/Kernel/Log/LogManagerTest.php
+++ b/tests/Kernel/Log/LogManagerTest.php
@@ -208,7 +208,7 @@ class LogManagerTest extends TestCase
         ]);
         $log = \Mockery::mock(LogManager::class, [$app])
                 ->shouldAllowMockingProtectedMethods()
-                ->shouldDeferMissing();
+                ->makePartial();
 
         $this->assertInstanceOf(Logger::class, $log->createStackDriver(['channels' => ['single']]));
         $this->assertInstanceOf(Logger::class, $log->createSlackDriver(['url' => 'https://easywechat.com']));
@@ -222,7 +222,7 @@ class LogManagerTest extends TestCase
         $app = new ServiceContainer([]);
         $log = \Mockery::mock(LogManager::class, [$app])
             ->shouldAllowMockingProtectedMethods()
-            ->shouldDeferMissing();
+            ->makePartial();
 
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid log level.');

--- a/tests/Kernel/Log/LogManagerTest.php
+++ b/tests/Kernel/Log/LogManagerTest.php
@@ -58,7 +58,7 @@ class LogManagerTest extends TestCase
         $log = \Mockery::mock(LogManager::class.'[createEmergencyLogger]', [$app])->shouldAllowMockingProtectedMethods();
 
         $emergencyLogger = \Mockery::mock(Logger::class);
-        $log->shouldReceive('createEmergencyLogger')->andReturn($emergencyLogger)->once();
+        $log->shouldReceive('createEmergencyLogger')->andReturn($emergencyLogger);
         $emergencyLogger->shouldReceive('emergency')
             ->with('Unable to create configured logger. Using emergency logger.', \Mockery::on(function ($data) {
                 $this->assertArrayHasKey('exception', $data);
@@ -112,7 +112,7 @@ class LogManagerTest extends TestCase
 
         $log = \Mockery::mock(LogManager::class.'[createEmergencyLogger]', [$app])->shouldAllowMockingProtectedMethods();
         $emergencyLogger = \Mockery::mock(Logger::class);
-        $log->shouldReceive('createEmergencyLogger')->andReturn($emergencyLogger)->once();
+        $log->shouldReceive('createEmergencyLogger')->andReturn($emergencyLogger);
         $emergencyLogger->shouldReceive('emergency')
             ->with('Unable to create configured logger. Using emergency logger.', \Mockery::on(function ($data) {
                 $this->assertArrayHasKey('exception', $data);
@@ -120,7 +120,7 @@ class LogManagerTest extends TestCase
                 $this->assertSame('Driver [abcde] is not supported.', $data['exception']->getMessage());
 
                 return true;
-            }))->once();
+            }));
         $log->driver('custom');
     }
 
@@ -142,16 +142,16 @@ class LogManagerTest extends TestCase
 
         $logger = \Mockery::mock(Logger::class);
 
-        $log->shouldReceive('createSingleDriver')->andReturn($logger)->once();
-        $logger->shouldReceive('emergency')->with('emergency message', [])->once();
-        $logger->shouldReceive('alert')->with('alert message', [])->once();
-        $logger->shouldReceive('critical')->with('critical message', [])->once();
-        $logger->shouldReceive('error')->with('error message', [])->once();
-        $logger->shouldReceive('warning')->with('warning message', [])->once();
-        $logger->shouldReceive('notice')->with('notice message', [])->once();
-        $logger->shouldReceive('info')->with('info message', [])->once();
-        $logger->shouldReceive('debug')->with('debug message', [])->once();
-        $logger->shouldReceive('log')->with('debug', 'log message', [])->once();
+        $log->shouldReceive('createSingleDriver')->andReturn($logger);
+        $logger->shouldReceive('emergency')->with('emergency message', []);
+        $logger->shouldReceive('alert')->with('alert message', []);
+        $logger->shouldReceive('critical')->with('critical message', []);
+        $logger->shouldReceive('error')->with('error message', []);
+        $logger->shouldReceive('warning')->with('warning message', []);
+        $logger->shouldReceive('notice')->with('notice message', []);
+        $logger->shouldReceive('info')->with('info message', []);
+        $logger->shouldReceive('debug')->with('debug message', []);
+        $logger->shouldReceive('log')->with('debug', 'log message', []);
 
         $log->emergency('emergency message');
         $log->alert('alert message');
@@ -185,8 +185,8 @@ class LogManagerTest extends TestCase
 
         $log->setDefaultDriver('single');
 
-        $log->shouldReceive('createSingleDriver')->andReturn($logger)->once();
-        $logger->shouldReceive('debug')->with('debug message', [])->once();
+        $log->shouldReceive('createSingleDriver')->andReturn($logger);
+        $logger->shouldReceive('debug')->with('debug message', []);
 
         $log->debug('debug message');
 

--- a/tests/Kernel/ServerGuardTest.php
+++ b/tests/Kernel/ServerGuardTest.php
@@ -30,13 +30,13 @@ class ServerGuardTest extends TestCase
     {
         $response = new Response('success');
         $logger = \Mockery::mock('stdClass');
-        $logger->expects()->debug('Server response created:', ['content' => 'success'])->once();
+        $logger->expects()->debug('Server response created:', ['content' => 'success']);
         $logger->expects()->debug('Request received:', [
             'method' => 'POST',
             'uri' => 'http://localhost/path/to/resource?foo=bar',
             'content-type' => 'xml',
             'content' => '<xml><name>foo</name></xml>',
-        ])->once();
+        ]);
 
         $request = Request::create('/path/to/resource?foo=bar', 'POST', ['foo' => 'bar'], [], [], [
             'CONTENT_TYPE' => ['application/xml'],
@@ -48,8 +48,8 @@ class ServerGuardTest extends TestCase
         ]);
 
         $guard = \Mockery::mock(ServerGuard::class.'[validate,resolve]', [$app])->shouldAllowMockingProtectedMethods();
-        $guard->expects()->validate()->andReturnSelf()->once();
-        $guard->expects()->resolve()->andReturn($response)->once();
+        $guard->expects()->validate()->andReturnSelf();
+        $guard->expects()->resolve()->andReturn($response);
 
         $this->assertSame($response, $guard->serve());
     }
@@ -274,7 +274,7 @@ class ServerGuardTest extends TestCase
             'from' => 'easywechat',
             'response' => 'hello overtrue!',
         ]);
-        $guard->expects()->shouldReturnRawResponse()->andReturn(true)->once();
+        $guard->expects()->shouldReturnRawResponse()->andReturn(true);
         $this->assertSame('hello overtrue!', $guard->resolve()->getContent());
     }
 
@@ -354,7 +354,7 @@ class ServerGuardTest extends TestCase
         sort($params, SORT_STRING);
         $signature = sha1(implode($params));
         $logger = \Mockery::mock('stdClass');
-        $logger->expects()->debug('Messages safe mode is enabled.')->once();
+        $logger->expects()->debug('Messages safe mode is enabled.');
         $request = Request::create('/path/to/resource?foo=bar', 'POST', [
             'timestamp' => $time,
             'nonce' => $nonce,
@@ -393,8 +393,8 @@ class ServerGuardTest extends TestCase
             'FromUserName' => 'overtrue',
             'ToUserName' => 'easywechat',
         ];
-        $guard->expects()->getMessage()->andReturn($message)->once();
-        $guard->expects()->dispatch(ServerGuard::MESSAGE_TYPE_MAPPING['text'], $message)->andReturn('mock-response')->once();
+        $guard->expects()->getMessage()->andReturn($message);
+        $guard->expects()->dispatch(ServerGuard::MESSAGE_TYPE_MAPPING['text'], $message)->andReturn('mock-response');
         $this->assertSame([
             'to' => 'overtrue',
             'from' => 'easywechat',
@@ -407,8 +407,8 @@ class ServerGuardTest extends TestCase
             'ToUserName' => 'easywechat',
             'MsgType' => 'image',
         ];
-        $guard->expects()->getMessage()->andReturn($message)->once();
-        $guard->expects()->dispatch(ServerGuard::MESSAGE_TYPE_MAPPING['image'], $message)->andReturn('mock-response')->once();
+        $guard->expects()->getMessage()->andReturn($message);
+        $guard->expects()->dispatch(ServerGuard::MESSAGE_TYPE_MAPPING['image'], $message)->andReturn('mock-response');
         $this->assertSame([
             'to' => 'overtrue',
             'from' => 'easywechat',
@@ -421,8 +421,8 @@ class ServerGuardTest extends TestCase
         $message->ToUserName = 'easywechat';
         $message->MsgType = 'file';
 
-        $guard->expects()->getMessage()->andReturn($message)->once();
-        $guard->expects()->dispatch(ServerGuard::MESSAGE_TYPE_MAPPING['file'], $message)->andReturn('mock-response')->once();
+        $guard->expects()->getMessage()->andReturn($message);
+        $guard->expects()->dispatch(ServerGuard::MESSAGE_TYPE_MAPPING['file'], $message)->andReturn('mock-response');
         $this->assertSame([
             'to' => 'overtrue',
             'from' => 'easywechat',

--- a/tests/Kernel/Traits/HasHttpRequestsTest.php
+++ b/tests/Kernel/Traits/HasHttpRequestsTest.php
@@ -80,7 +80,7 @@ class HasHttpRequestsTest extends TestCase
             ],
             'handler' => $handlerStack,
             'base_uri' => 'http://easywechat.com',
-        ])->andReturn($response)->once();
+        ])->andReturn($response);
 
         $this->assertSame($response, $cls->request('foo/bar'));
 
@@ -92,7 +92,7 @@ class HasHttpRequestsTest extends TestCase
             'query' => ['foo' => 'bar'],
             'handler' => $handlerStack,
             'base_uri' => 'http://easywechat.com',
-        ])->andReturn($response)->once();
+        ])->andReturn($response);
 
         $this->assertSame($response, $cls->request('foo/bar', 'post', ['query' => ['foo' => 'bar']]));
     }
@@ -135,7 +135,7 @@ class HasHttpRequestsTest extends TestCase
                 'Content-Type' => 'application/json',
             ],
             'base_uri' => 'http://easywechat.com',
-        ])->andReturn($response)->once();
+        ])->andReturn($response);
 
         $this->assertSame($response, $cls->request('foo/bar', 'POST', [
             'json' => [],
@@ -152,7 +152,7 @@ class HasHttpRequestsTest extends TestCase
                 'Content-Type' => 'application/json',
             ],
             'base_uri' => 'http://easywechat.com',
-        ])->andReturn($response)->once();
+        ])->andReturn($response);
 
         $cls->request('foo/bar', 'POST', [
             'json' => ['name' => '中文'],

--- a/tests/Kernel/Traits/ObservableTest.php
+++ b/tests/Kernel/Traits/ObservableTest.php
@@ -129,13 +129,13 @@ class ObservableTest extends TestCase
     {
         $c = new DummyClassForObservableTest();
         $handler1 = \Mockery::mock(EventHandlerInterface::class);
-        $handler1->expects()->handle(['foo' => 'bar'])->andReturn('mock-response')->once();
+        $handler1->expects()->handle(['foo' => 'bar'])->andReturn('mock-response');
 
         $handler2 = \Mockery::mock(EventHandlerInterface::class);
-        $handler2->expects()->handle(['foo' => 'bar'])->andReturn(true)->once();
+        $handler2->expects()->handle(['foo' => 'bar'])->andReturn(true);
 
         $handler3 = \Mockery::mock(EventHandlerInterface::class);
-        $handler3->expects()->handle(['foo' => 'bar'])->andReturn('mock-response-2')->once();
+        $handler3->expects()->handle(['foo' => 'bar'])->andReturn('mock-response-2');
 
         $c->push($handler1);
         $c->push($handler2);
@@ -147,10 +147,10 @@ class ObservableTest extends TestCase
     {
         $c = new DummyClassForObservableTest();
         $handler1 = \Mockery::mock(EventHandlerInterface::class);
-        $handler1->expects()->handle(['foo' => 'bar'])->andReturn(null)->once();
+        $handler1->expects()->handle(['foo' => 'bar'])->andReturn(null);
 
         $handler2 = \Mockery::mock(EventHandlerInterface::class);
-        $handler2->expects()->handle(['foo' => 'bar'])->andReturn(false)->once();
+        $handler2->expects()->handle(['foo' => 'bar'])->andReturn(false);
 
         $handler3 = \Mockery::mock(EventHandlerInterface::class);
         $handler3->expects()->handle(['foo' => 'bar'])->andReturn('mock-result')->never();
@@ -199,19 +199,19 @@ class ObservableTest extends TestCase
             'message' => 'handler2 exception thrown.',
             'file' => __FILE__,
             'line' => $line,
-        ])->once();
+        ]);
         $app = new ServiceContainer([], [
             'logger' => $logger,
         ]);
         $c = new DummyClassForObservableTest($app);
         $handler1 = \Mockery::mock(EventHandlerInterface::class);
-        $handler1->expects()->handle(['foo' => 'bar'])->andReturn('mock-response')->once();
+        $handler1->expects()->handle(['foo' => 'bar'])->andReturn('mock-response');
 
         $handler2 = \Mockery::mock(EventHandlerInterface::class);
-        $handler2->expects()->handle(['foo' => 'bar'])->andThrow($exception)->once();
+        $handler2->expects()->handle(['foo' => 'bar'])->andThrow($exception);
 
         $handler3 = \Mockery::mock(EventHandlerInterface::class);
-        $handler3->expects()->handle(['foo' => 'bar'])->andReturn('mock-response-3')->once();
+        $handler3->expects()->handle(['foo' => 'bar'])->andReturn('mock-response-3');
 
         $c->push($handler1);
         $c->push($handler2);
@@ -223,7 +223,7 @@ class ObservableTest extends TestCase
     {
         $c = new DummyClassForObservableTest();
         $handler1 = \Mockery::mock(EventHandlerInterface::class);
-        $handler1->expects()->handle(['foo' => 'bar'])->andReturn(new TerminateResult('mock-terminate-response'))->once();
+        $handler1->expects()->handle(['foo' => 'bar'])->andReturn(new TerminateResult('mock-terminate-response'));
 
         $handler2 = \Mockery::mock(EventHandlerInterface::class);
         $handler2->expects()->handle(['foo' => 'bar'])->andThrow(new Exception('foo'))->never();
@@ -242,16 +242,16 @@ class ObservableTest extends TestCase
         $c = new DummyClassForObservableTest();
 
         $handler0 = \Mockery::mock(EventHandlerInterface::class);
-        $handler0->expects()->handle(['foo' => 'bar'])->andReturn('mock-first-response')->once();
+        $handler0->expects()->handle(['foo' => 'bar'])->andReturn('mock-first-response');
 
         $handler1 = \Mockery::mock(EventHandlerInterface::class);
-        $handler1->expects()->handle(['foo' => 'bar'])->andReturn(new FinallyResult('mock-finally-response'))->once();
+        $handler1->expects()->handle(['foo' => 'bar'])->andReturn(new FinallyResult('mock-finally-response'));
 
         $handler2 = \Mockery::mock(EventHandlerInterface::class);
-        $handler2->expects()->handle(['foo' => 'bar'])->andReturn('mock-response-2')->once();
+        $handler2->expects()->handle(['foo' => 'bar'])->andReturn('mock-response-2');
 
         $handler3 = \Mockery::mock(EventHandlerInterface::class);
-        $handler3->expects()->handle(['foo' => 'bar'])->andReturn('mock-response-3')->once();
+        $handler3->expects()->handle(['foo' => 'bar'])->andReturn('mock-response-3');
 
         $c->push($handler0);
         $c->push($handler1);
@@ -278,7 +278,7 @@ class ObservableTest extends TestCase
         // class instance
         $c = new DummyClassForObservableTest();
         $handler = \Mockery::mock(EventHandlerInterface::class);
-        $handler->expects()->handle(['foo' => 'bar'])->andReturn('class instance handle')->once();
+        $handler->expects()->handle(['foo' => 'bar'])->andReturn('class instance handle');
         $c->push($handler, 'foo');
         $this->assertSame('class instance handle', $c->getHandlers()['foo'][0](['foo' => 'bar']));
     }

--- a/tests/MiniProgram/ActivityMessage/ClientTest.php
+++ b/tests/MiniProgram/ActivityMessage/ClientTest.php
@@ -21,7 +21,7 @@ class ClientTest extends TestCase
     {
         $client = $this->mockApiClient(Client::class);
 
-        $client->expects()->httpGet('cgi-bin/message/wxopen/activityid/create')->andReturn('mock-result')->once();
+        $client->expects()->httpGet('cgi-bin/message/wxopen/activityid/create')->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->createActivityId());
     }

--- a/tests/MiniProgram/AppCode/ClientTest.php
+++ b/tests/MiniProgram/AppCode/ClientTest.php
@@ -33,7 +33,7 @@ class ClientTest extends TestCase
         $client->expects()->requestRaw('wxa/getwxacode', 'POST', ['json' => [
             'path' => 'foo-path',
             'width' => 430,
-        ]])->andReturn($this->mockStream)->once();
+        ]])->andReturn($this->mockStream);
 
         $this->assertInstanceOf(StreamResponse::class, $client->get('foo-path', [
             'width' => 430,
@@ -47,7 +47,7 @@ class ClientTest extends TestCase
         $client->expects()->requestRaw('wxa/getwxacodeunlimit', 'POST', ['json' => [
             'scene' => 'scene',
             'page' => '/app/pages/hello',
-        ]])->andReturn($this->mockStream)->once();
+        ]])->andReturn($this->mockStream);
 
         $this->assertInstanceOf(StreamResponse::class, $client->getUnlimit('scene', [
             'page' => '/app/pages/hello',
@@ -61,7 +61,7 @@ class ClientTest extends TestCase
         $client->expects()->requestRaw('cgi-bin/wxaapp/createwxaqrcode', 'POST', ['json' => [
             'path' => 'foo-path',
             'width' => null,
-        ]])->andReturn($this->mockStream)->once();
+        ]])->andReturn($this->mockStream);
 
         $this->assertInstanceOf(StreamResponse::class, $client->getQrCode('foo-path'));
     }

--- a/tests/MiniProgram/Auth/AuthTest.php
+++ b/tests/MiniProgram/Auth/AuthTest.php
@@ -26,7 +26,7 @@ class AuthTest extends TestCase
             'secret' => 'mock-secret',
             'js_code' => 'js-code',
             'grant_type' => 'authorization_code',
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->session('js-code'));
     }

--- a/tests/MiniProgram/DataCube/ClientTest.php
+++ b/tests/MiniProgram/DataCube/ClientTest.php
@@ -20,7 +20,7 @@ class ClientTest extends TestCase
     {
         $client = $this->mockApiClient(Client::class, ['query']);
 
-        $client->expects()->query('datacube/getweanalysisappiddailysummarytrend', '2017-08-02', '2017-08-10')->andReturn('mock-result')->once();
+        $client->expects()->query('datacube/getweanalysisappiddailysummarytrend', '2017-08-02', '2017-08-10')->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->summaryTrend('2017-08-02', '2017-08-10'));
     }
@@ -29,7 +29,7 @@ class ClientTest extends TestCase
     {
         $client = $this->mockApiClient(Client::class, ['query']);
 
-        $client->expects()->query('datacube/getweanalysisappiddailyvisittrend', '2017-08-02', '2017-08-10')->andReturn('mock-result')->once();
+        $client->expects()->query('datacube/getweanalysisappiddailyvisittrend', '2017-08-02', '2017-08-10')->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->dailyVisitTrend('2017-08-02', '2017-08-10'));
     }
@@ -38,7 +38,7 @@ class ClientTest extends TestCase
     {
         $client = $this->mockApiClient(Client::class, ['query']);
 
-        $client->expects()->query('datacube/getweanalysisappidweeklyvisittrend', '2017-08-02', '2017-08-10')->andReturn('mock-result')->once();
+        $client->expects()->query('datacube/getweanalysisappidweeklyvisittrend', '2017-08-02', '2017-08-10')->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->weeklyVisitTrend('2017-08-02', '2017-08-10'));
     }
@@ -47,7 +47,7 @@ class ClientTest extends TestCase
     {
         $client = $this->mockApiClient(Client::class, ['query']);
 
-        $client->expects()->query('datacube/getweanalysisappidmonthlyvisittrend', '2017-08-02', '2017-08-10')->andReturn('mock-result')->once();
+        $client->expects()->query('datacube/getweanalysisappidmonthlyvisittrend', '2017-08-02', '2017-08-10')->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->monthlyVisitTrend('2017-08-02', '2017-08-10'));
     }
@@ -56,7 +56,7 @@ class ClientTest extends TestCase
     {
         $client = $this->mockApiClient(Client::class, ['query']);
 
-        $client->expects()->query('datacube/getweanalysisappidvisitdistribution', '2017-08-02', '2017-08-10')->andReturn('mock-result')->once();
+        $client->expects()->query('datacube/getweanalysisappidvisitdistribution', '2017-08-02', '2017-08-10')->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->visitDistribution('2017-08-02', '2017-08-10'));
     }
@@ -65,7 +65,7 @@ class ClientTest extends TestCase
     {
         $client = $this->mockApiClient(Client::class, ['query']);
 
-        $client->expects()->query('datacube/getweanalysisappiddailyretaininfo', '2017-08-02', '2017-08-10')->andReturn('mock-result')->once();
+        $client->expects()->query('datacube/getweanalysisappiddailyretaininfo', '2017-08-02', '2017-08-10')->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->dailyRetainInfo('2017-08-02', '2017-08-10'));
     }
@@ -74,7 +74,7 @@ class ClientTest extends TestCase
     {
         $client = $this->mockApiClient(Client::class, ['query']);
 
-        $client->expects()->query('datacube/getweanalysisappidweeklyretaininfo', '2017-08-02', '2017-08-10')->andReturn('mock-result')->once();
+        $client->expects()->query('datacube/getweanalysisappidweeklyretaininfo', '2017-08-02', '2017-08-10')->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->weeklyRetainInfo('2017-08-02', '2017-08-10'));
     }
@@ -83,7 +83,7 @@ class ClientTest extends TestCase
     {
         $client = $this->mockApiClient(Client::class, ['query']);
 
-        $client->expects()->query('datacube/getweanalysisappidmonthlyretaininfo', '2017-08-02', '2017-08-10')->andReturn('mock-result')->once();
+        $client->expects()->query('datacube/getweanalysisappidmonthlyretaininfo', '2017-08-02', '2017-08-10')->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->monthlyRetainInfo('2017-08-02', '2017-08-10'));
     }
@@ -92,7 +92,7 @@ class ClientTest extends TestCase
     {
         $client = $this->mockApiClient(Client::class, ['query']);
 
-        $client->expects()->query('datacube/getweanalysisappidvisitpage', '2017-08-02', '2017-08-10')->andReturn('mock-result')->once();
+        $client->expects()->query('datacube/getweanalysisappidvisitpage', '2017-08-02', '2017-08-10')->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->visitPage('2017-08-02', '2017-08-10'));
     }
@@ -101,7 +101,7 @@ class ClientTest extends TestCase
     {
         $client = $this->mockApiClient(Client::class, ['query']);
 
-        $client->expects()->query('datacube/getweanalysisappiduserportrait', '2017-08-02', '2017-08-10')->andReturn('mock-result')->once();
+        $client->expects()->query('datacube/getweanalysisappiduserportrait', '2017-08-02', '2017-08-10')->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->userPortrait('2017-08-02', '2017-08-10'));
     }
@@ -113,7 +113,7 @@ class ClientTest extends TestCase
         $client->expects()->httpPostJson('path/to/api', [
             'begin_date' => '2017-08-02',
             'end_date' => '2017-08-10',
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->query('path/to/api', '2017-08-02', '2017-08-10'));
     }

--- a/tests/MiniProgram/Express/ClientTest.php
+++ b/tests/MiniProgram/Express/ClientTest.php
@@ -20,7 +20,7 @@ class ClientTest extends TestCase
     {
         $client = $this->mockApiClient(Client::class);
 
-        $client->expects()->httpGet('cgi-bin/express/business/delivery/getall')->andReturn('mock-result')->once();
+        $client->expects()->httpGet('cgi-bin/express/business/delivery/getall')->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->listProviders());
     }
@@ -92,7 +92,7 @@ class ClientTest extends TestCase
             ],
         ];
 
-        $client->expects()->httpPostJson('cgi-bin/express/business/order/add', $data)->andReturn('mock-result')->once();
+        $client->expects()->httpPostJson('cgi-bin/express/business/order/add', $data)->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->createWaybill($data));
     }
@@ -108,7 +108,7 @@ class ClientTest extends TestCase
             'waybill_id' => '000000000',
         ];
 
-        $client->expects()->httpPostJson('cgi-bin/express/business/order/cancel', $data)->andReturn('mock-result')->once();
+        $client->expects()->httpPostJson('cgi-bin/express/business/order/cancel', $data)->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->deleteWaybill($data));
     }
@@ -124,7 +124,7 @@ class ClientTest extends TestCase
             'waybill_id' => '000000000',
         ];
 
-        $client->expects()->httpPostJson('cgi-bin/express/business/order/get', $data)->andReturn('mock-result')->once();
+        $client->expects()->httpPostJson('cgi-bin/express/business/order/get', $data)->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->getWaybill($data));
     }
@@ -140,7 +140,7 @@ class ClientTest extends TestCase
             'waybill_id' => '000000000',
         ];
 
-        $client->expects()->httpPostJson('cgi-bin/express/business/path/get', $data)->andReturn('mock-result')->once();
+        $client->expects()->httpPostJson('cgi-bin/express/business/path/get', $data)->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->getWaybillTrack($data));
     }
@@ -154,7 +154,7 @@ class ClientTest extends TestCase
             'biz_id' => 'xyz',
         ];
 
-        $client->expects()->httpPostJson('cgi-bin/express/business/quota/get', $data)->andReturn('mock-result')->once();
+        $client->expects()->httpPostJson('cgi-bin/express/business/quota/get', $data)->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->getBalance('YTO', 'xyz'));
     }
@@ -168,7 +168,7 @@ class ClientTest extends TestCase
             'update_type' => 'bind',
         ];
 
-        $client->expects()->httpPostJson('cgi-bin/express/business/printer/update', $data)->andReturn('mock-result')->once();
+        $client->expects()->httpPostJson('cgi-bin/express/business/printer/update', $data)->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->bindPrinter('myopenid'));
     }
@@ -182,7 +182,7 @@ class ClientTest extends TestCase
             'update_type' => 'unbind',
         ];
 
-        $client->expects()->httpPostJson('cgi-bin/express/business/printer/update', $data)->andReturn('mock-result')->once();
+        $client->expects()->httpPostJson('cgi-bin/express/business/printer/update', $data)->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->unbindPrinter('myopenid'));
     }

--- a/tests/MiniProgram/NearbyPoi/ClientTest.php
+++ b/tests/MiniProgram/NearbyPoi/ClientTest.php
@@ -26,7 +26,7 @@ class ClientTest extends TestCase
             'related_credential' => 'mock-credential',
             'related_address' => 'mock-address',
             'related_proof_material' => 'mock-proof-material',
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->add('mock-name', 'mock-credential', 'mock-address', 'mock-proof-material'));
     }
@@ -35,7 +35,7 @@ class ClientTest extends TestCase
     {
         $client = $this->mockApiClient(Client::class);
 
-        $client->expects()->httpPostJson('wxa/delnearbypoi', ['poi_id' => 'mock-poi-id'])->andReturn('mock-result')->once();
+        $client->expects()->httpPostJson('wxa/delnearbypoi', ['poi_id' => 'mock-poi-id'])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->delete('mock-poi-id'));
     }
@@ -44,7 +44,7 @@ class ClientTest extends TestCase
     {
         $client = $this->mockApiClient(Client::class);
 
-        $client->expects()->httpGet('wxa/getnearbypoilist', ['page' => 5, 'page_rows' => 10])->andReturn('mock-result')->once();
+        $client->expects()->httpGet('wxa/getnearbypoilist', ['page' => 5, 'page_rows' => 10])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->list(5, 10));
     }
@@ -65,7 +65,7 @@ class ClientTest extends TestCase
         $client->expects()->httpPostJson('wxa/setnearbypoishowstatus', [
             'poi_id' => 'mock-poi-id',
             'status' => 0,
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->setVisibility('mock-poi-id', 0));
     }

--- a/tests/MiniProgram/Plugin/ClientTest.php
+++ b/tests/MiniProgram/Plugin/ClientTest.php
@@ -20,7 +20,7 @@ class ClientTest extends TestCase
     {
         $client = $this->mockApiClient(Client::class);
 
-        $client->expects()->httpPostJson('wxa/plugin', ['action' => 'apply', 'plugin_appid' => 'plugin-app-id'])->andReturn('mock-result')->once();
+        $client->expects()->httpPostJson('wxa/plugin', ['action' => 'apply', 'plugin_appid' => 'plugin-app-id'])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->apply('plugin-app-id'));
     }
@@ -29,7 +29,7 @@ class ClientTest extends TestCase
     {
         $client = $this->mockApiClient(Client::class);
 
-        $client->expects()->httpPostJson('wxa/plugin', ['action' => 'list'])->andReturn('mock-result')->once();
+        $client->expects()->httpPostJson('wxa/plugin', ['action' => 'list'])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->list());
     }
@@ -38,7 +38,7 @@ class ClientTest extends TestCase
     {
         $client = $this->mockApiClient(Client::class);
 
-        $client->expects()->httpPostJson('wxa/plugin', ['action' => 'unbind', 'plugin_appid' => 'plugin-app-id'])->andReturn('mock-result')->once();
+        $client->expects()->httpPostJson('wxa/plugin', ['action' => 'unbind', 'plugin_appid' => 'plugin-app-id'])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->unbind('plugin-app-id'));
     }

--- a/tests/MiniProgram/TemplateMessage/ClientTest.php
+++ b/tests/MiniProgram/TemplateMessage/ClientTest.php
@@ -44,7 +44,7 @@ class ClientTest extends TestCase
             'form_id' => 'mock-form_id',
             'emphasis_keyword' => '',
             'data' => [],
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->send(['touser' => 'mock-openid', 'template_id' => 'mock-template_id', 'form_id' => 'mock-form_id']));
     }
 
@@ -52,7 +52,7 @@ class ClientTest extends TestCase
     {
         $client = $this->mockApiClient(Client::class);
 
-        $client->expects()->httpPostJson('cgi-bin/wxopen/template/library/list', ['offset' => 5, 'count' => 10])->andReturn('mock-result')->once();
+        $client->expects()->httpPostJson('cgi-bin/wxopen/template/library/list', ['offset' => 5, 'count' => 10])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->list(5, 10));
     }
@@ -61,7 +61,7 @@ class ClientTest extends TestCase
     {
         $client = $this->mockApiClient(Client::class);
 
-        $client->expects()->httpPostJson('cgi-bin/wxopen/template/library/get', ['id' => 'A123'])->andReturn('mock-result')->once();
+        $client->expects()->httpPostJson('cgi-bin/wxopen/template/library/get', ['id' => 'A123'])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->get('A123'));
     }
@@ -70,7 +70,7 @@ class ClientTest extends TestCase
     {
         $client = $this->mockApiClient(Client::class);
 
-        $client->expects()->httpPostJson('cgi-bin/wxopen/template/add', ['id' => 'A123', 'keyword_id_list' => ['foo', 'bar']])->andReturn('mock-result')->once();
+        $client->expects()->httpPostJson('cgi-bin/wxopen/template/add', ['id' => 'A123', 'keyword_id_list' => ['foo', 'bar']])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->add('A123', ['foo', 'bar']));
     }
@@ -79,7 +79,7 @@ class ClientTest extends TestCase
     {
         $client = $this->mockApiClient(Client::class);
 
-        $client->expects()->httpPostJson('cgi-bin/wxopen/template/del', ['template_id' => 'A123'])->andReturn('mock-result')->once();
+        $client->expects()->httpPostJson('cgi-bin/wxopen/template/del', ['template_id' => 'A123'])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->delete('A123'));
     }
@@ -88,7 +88,7 @@ class ClientTest extends TestCase
     {
         $client = $this->mockApiClient(Client::class);
 
-        $client->expects()->httpPostJson('cgi-bin/wxopen/template/list', ['offset' => 5, 'count' => 10])->andReturn('mock-result')->once();
+        $client->expects()->httpPostJson('cgi-bin/wxopen/template/list', ['offset' => 5, 'count' => 10])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->getTemplates(5, 10));
     }

--- a/tests/OfficialAccount/AutoReply/ClientTest.php
+++ b/tests/OfficialAccount/AutoReply/ClientTest.php
@@ -19,7 +19,7 @@ class ClientTest extends TestCase
     public function testCurrent()
     {
         $client = $this->mockApiClient(Client::class);
-        $client->expects()->httpGet('cgi-bin/get_current_autoreply_info')->andReturn('mock-result')->once();
+        $client->expects()->httpGet('cgi-bin/get_current_autoreply_info')->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->current());
     }

--- a/tests/OfficialAccount/Base/ClientTest.php
+++ b/tests/OfficialAccount/Base/ClientTest.php
@@ -23,7 +23,7 @@ class ClientTest extends TestCase
 
         $client->expects()->httpPostJson('cgi-bin/clear_quota', [
             'appid' => '123456',
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->clearQuota());
     }
@@ -32,7 +32,7 @@ class ClientTest extends TestCase
     {
         $client = $this->mockApiClient(Client::class);
 
-        $client->expects()->httpGet('cgi-bin/getcallbackip')->andReturn('mock-result')->once();
+        $client->expects()->httpGet('cgi-bin/getcallbackip')->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->getValidIps());
     }

--- a/tests/OfficialAccount/Broadcasting/ClientTest.php
+++ b/tests/OfficialAccount/Broadcasting/ClientTest.php
@@ -34,7 +34,7 @@ class ClientTest extends TestCase
                 'foo' => 'bar',
             ],
         ];
-        $c->expects()->httpPostJson('cgi-bin/message/mass/sendall', $message)->andReturn('mock-result')->once();
+        $c->expects()->httpPostJson('cgi-bin/message/mass/sendall', $message)->andReturn('mock-result');
         $this->assertSame('mock-result', $c->send($message));
 
         // to tag
@@ -47,7 +47,7 @@ class ClientTest extends TestCase
                 'foo' => 'bar',
             ],
         ];
-        $c->expects()->httpPostJson('cgi-bin/message/mass/sendall', $message)->andReturn('mock-result')->once();
+        $c->expects()->httpPostJson('cgi-bin/message/mass/sendall', $message)->andReturn('mock-result');
         $this->assertSame('mock-result', $c->send($message));
 
         // to users
@@ -57,7 +57,7 @@ class ClientTest extends TestCase
                 'foo' => 'bar',
             ],
         ];
-        $c->expects()->httpPostJson('cgi-bin/message/mass/send', $message)->andReturn('mock-result')->once();
+        $c->expects()->httpPostJson('cgi-bin/message/mass/send', $message)->andReturn('mock-result');
         $this->assertSame('mock-result', $c->send($message));
 
         // exception
@@ -80,7 +80,7 @@ class ClientTest extends TestCase
                 'foo' => 'bar',
             ],
         ];
-        $c->expects()->httpPostJson('cgi-bin/message/mass/preview', $message)->andReturn('mock-result')->once();
+        $c->expects()->httpPostJson('cgi-bin/message/mass/preview', $message)->andReturn('mock-result');
         $this->assertSame('mock-result', $c->preview($message));
     }
 
@@ -90,7 +90,7 @@ class ClientTest extends TestCase
         $msgId = 'mock-msg-id';
         $c->expects()->httpPostJson('cgi-bin/message/mass/delete', [
             'msg_id' => $msgId,
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
         $this->assertSame('mock-result', $c->delete($msgId));
     }
 
@@ -100,7 +100,7 @@ class ClientTest extends TestCase
         $msgId = 'mock-msg-id';
         $c->expects()->httpPostJson('cgi-bin/message/mass/get', [
             'msg_id' => $msgId,
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
         $this->assertSame('mock-result', $c->status($msgId));
     }
 
@@ -109,7 +109,7 @@ class ClientTest extends TestCase
         $c = $this->mockApiClient(Client::class, ['sendMessage']);
         $c->expects()->sendMessage(\Mockery::on(function ($message) {
             return $message instanceof Text && 'hello world!' === $message->content;
-        }), 'overtrue', ['send_ignore_reprint' => 1])->andReturn('mock-result')->once();
+        }), 'overtrue', ['send_ignore_reprint' => 1])->andReturn('mock-result');
         $this->assertSame('mock-result', $c->sendText('hello world!', 'overtrue', ['send_ignore_reprint' => 1]));
     }
 
@@ -118,7 +118,7 @@ class ClientTest extends TestCase
         $c = $this->mockApiClient(Client::class, ['sendMessage']);
         $c->expects()->sendMessage(\Mockery::on(function ($message) {
             return $message instanceof Media && 'mpnews' === $message->getType() && 'mock-media-id' === $message->media_id;
-        }), 'overtrue', ['send_ignore_reprint' => 1])->andReturn('mock-result')->once();
+        }), 'overtrue', ['send_ignore_reprint' => 1])->andReturn('mock-result');
         $this->assertSame('mock-result', $c->sendNews('mock-media-id', 'overtrue', ['send_ignore_reprint' => 1]));
     }
 
@@ -127,7 +127,7 @@ class ClientTest extends TestCase
         $c = $this->mockApiClient(Client::class, ['sendMessage']);
         $c->expects()->sendMessage(\Mockery::on(function ($message) {
             return $message instanceof Media && 'voice' === $message->getType() && 'mock-media-id' === $message->media_id;
-        }), 'overtrue', ['send_ignore_reprint' => 1])->andReturn('mock-result')->once();
+        }), 'overtrue', ['send_ignore_reprint' => 1])->andReturn('mock-result');
         $this->assertSame('mock-result', $c->sendVoice('mock-media-id', 'overtrue', ['send_ignore_reprint' => 1]));
     }
 
@@ -136,7 +136,7 @@ class ClientTest extends TestCase
         $c = $this->mockApiClient(Client::class, ['sendMessage']);
         $c->expects()->sendMessage(\Mockery::on(function ($message) {
             return $message instanceof Media && 'mpvideo' === $message->getType() && 'mock-media-id' === $message->media_id;
-        }), 'overtrue', ['send_ignore_reprint' => 1])->andReturn('mock-result')->once();
+        }), 'overtrue', ['send_ignore_reprint' => 1])->andReturn('mock-result');
         $this->assertSame('mock-result', $c->sendVideo('mock-media-id', 'overtrue', ['send_ignore_reprint' => 1]));
     }
 
@@ -145,7 +145,7 @@ class ClientTest extends TestCase
         $c = $this->mockApiClient(Client::class, ['sendMessage']);
         $c->expects()->sendMessage(\Mockery::on(function ($message) {
             return $message instanceof Image && 'mock-media-id' === $message->media_id;
-        }), 'overtrue', ['send_ignore_reprint' => 1])->andReturn('mock-result')->once();
+        }), 'overtrue', ['send_ignore_reprint' => 1])->andReturn('mock-result');
         $this->assertSame('mock-result', $c->sendImage('mock-media-id', 'overtrue', ['send_ignore_reprint' => 1]));
     }
 
@@ -154,7 +154,7 @@ class ClientTest extends TestCase
         $c = $this->mockApiClient(Client::class, ['sendMessage']);
         $c->expects()->sendMessage(\Mockery::on(function ($message) {
             return $message instanceof Card && 'mock-card-id' === $message->card_id;
-        }), 'overtrue', ['send_ignore_reprint' => 1])->andReturn('mock-result')->once();
+        }), 'overtrue', ['send_ignore_reprint' => 1])->andReturn('mock-result');
         $this->assertSame('mock-result', $c->sendCard('mock-card-id', 'overtrue', ['send_ignore_reprint' => 1]));
     }
 
@@ -163,7 +163,7 @@ class ClientTest extends TestCase
         $c = $this->mockApiClient(Client::class, ['previewMessage']);
         $c->expects()->previewMessage(\Mockery::on(function ($message) {
             return $message instanceof Text && 'hello world!' === $message->content;
-        }), 'openid', Client::PREVIEW_BY_OPENID)->andReturn('mock-result')->once();
+        }), 'openid', Client::PREVIEW_BY_OPENID)->andReturn('mock-result');
         $this->assertSame('mock-result', $c->previewText('hello world!', 'openid'));
     }
 
@@ -172,7 +172,7 @@ class ClientTest extends TestCase
         $c = $this->mockApiClient(Client::class, ['previewMessage']);
         $c->expects()->previewMessage(\Mockery::on(function ($message) {
             return $message instanceof Media && 'mpnews' === $message->getType() && 'mock-media-id' === $message->media_id;
-        }), 'openid', Client::PREVIEW_BY_OPENID)->andReturn('mock-result')->once();
+        }), 'openid', Client::PREVIEW_BY_OPENID)->andReturn('mock-result');
         $this->assertSame('mock-result', $c->previewNews('mock-media-id', 'openid'));
     }
 
@@ -181,7 +181,7 @@ class ClientTest extends TestCase
         $c = $this->mockApiClient(Client::class, ['previewMessage']);
         $c->expects()->previewMessage(\Mockery::on(function ($message) {
             return $message instanceof Media && 'voice' === $message->getType() && 'mock-media-id' === $message->media_id;
-        }), 'openid', Client::PREVIEW_BY_OPENID)->andReturn('mock-result')->once();
+        }), 'openid', Client::PREVIEW_BY_OPENID)->andReturn('mock-result');
         $this->assertSame('mock-result', $c->previewVoice('mock-media-id', 'openid'));
     }
 
@@ -190,7 +190,7 @@ class ClientTest extends TestCase
         $c = $this->mockApiClient(Client::class, ['previewMessage']);
         $c->expects()->previewMessage(\Mockery::on(function ($message) {
             return $message instanceof Media && 'mpvideo' === $message->getType() && 'mock-media-id' === $message->media_id;
-        }), 'openid', Client::PREVIEW_BY_OPENID)->andReturn('mock-result')->once();
+        }), 'openid', Client::PREVIEW_BY_OPENID)->andReturn('mock-result');
         $this->assertSame('mock-result', $c->previewVideo('mock-media-id', 'openid'));
     }
 
@@ -199,7 +199,7 @@ class ClientTest extends TestCase
         $c = $this->mockApiClient(Client::class, ['previewMessage']);
         $c->expects()->previewMessage(\Mockery::on(function ($message) {
             return $message instanceof Image && 'mock-media-id' === $message->media_id;
-        }), 'openid', Client::PREVIEW_BY_OPENID)->andReturn('mock-result')->once();
+        }), 'openid', Client::PREVIEW_BY_OPENID)->andReturn('mock-result');
         $this->assertSame('mock-result', $c->previewImage('mock-media-id', 'openid'));
     }
 
@@ -208,7 +208,7 @@ class ClientTest extends TestCase
         $c = $this->mockApiClient(Client::class, ['previewMessage']);
         $c->expects()->previewMessage(\Mockery::on(function ($message) {
             return $message instanceof Card && 'mock-card-id' === $message->card_id;
-        }), 'openid', Client::PREVIEW_BY_OPENID)->andReturn('mock-result')->once();
+        }), 'openid', Client::PREVIEW_BY_OPENID)->andReturn('mock-result');
         $this->assertSame('mock-result', $c->previewCard('mock-card-id', 'openid'));
     }
 
@@ -223,7 +223,7 @@ class ClientTest extends TestCase
             'text' => [
                 'content' => 'hello world!',
             ],
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $c->previewMessage(new Text('hello world!'), 'mock-openid'));
 
@@ -234,7 +234,7 @@ class ClientTest extends TestCase
             'text' => [
                 'content' => 'hello world!',
             ],
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $c->previewMessage(new Text('hello world!'), 'overtrue', Client::PREVIEW_BY_NAME));
     }
@@ -252,7 +252,7 @@ class ClientTest extends TestCase
             'text' => [
                 'content' => 'hello world!',
             ],
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $c->sendMessage(new Text('hello world!'));
 
@@ -266,7 +266,7 @@ class ClientTest extends TestCase
             'text' => [
                 'content' => 'hello world!',
             ],
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $c->sendMessage(new Text('hello world!'), 12);
 
@@ -277,7 +277,7 @@ class ClientTest extends TestCase
             'text' => [
                 'content' => 'hello world!',
             ],
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $c->sendMessage(new Text('hello world!'), ['openid1', 'openid2']);
     }

--- a/tests/OfficialAccount/Card/BoardingPassClientTest.php
+++ b/tests/OfficialAccount/Card/BoardingPassClientTest.php
@@ -23,7 +23,7 @@ class BoardingPassClientTest extends TestCase
         $params = [
             'foo' => 'bar',
         ];
-        $client->expects()->httpPostJson('card/boardingpass/checkin', $params)->andReturn('mock-result')->once();
+        $client->expects()->httpPostJson('card/boardingpass/checkin', $params)->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->checkin($params));
     }

--- a/tests/OfficialAccount/Card/ClientTest.php
+++ b/tests/OfficialAccount/Card/ClientTest.php
@@ -21,7 +21,7 @@ class ClientTest extends TestCase
     {
         $client = $this->mockApiClient(Client::class);
 
-        $client->expects()->httpGet('card/getcolors')->andReturn('mock-result')->once();
+        $client->expects()->httpGet('card/getcolors')->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->colors());
     }
@@ -30,7 +30,7 @@ class ClientTest extends TestCase
     {
         $client = $this->mockApiClient(Client::class);
 
-        $client->expects()->httpGet('card/getapplyprotocol')->andReturn('mock-result')->once();
+        $client->expects()->httpGet('card/getapplyprotocol')->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->categories());
     }
@@ -63,7 +63,7 @@ class ClientTest extends TestCase
                 'card_type' => 'MEMBER_CARD',
                 'member_card' => $attributes,
             ],
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->create('member_card', $attributes));
     }
@@ -72,7 +72,7 @@ class ClientTest extends TestCase
     {
         $client = $this->mockApiClient(Client::class);
 
-        $client->expects()->httpPostJson('card/qrcode/create', ['foo', 'bar'])->andReturn('mock-result')->once();
+        $client->expects()->httpPostJson('card/qrcode/create', ['foo', 'bar'])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->createQrCode(['foo', 'bar']));
     }
@@ -86,7 +86,7 @@ class ClientTest extends TestCase
             'ticket' => 'mock-ticket',
         ];
         $response = new Response(200, ['content-type' => 'image/jpeg'], 'mock-content');
-        $client->expects()->requestRaw($baseUri, 'GET', $params)->andReturn($response)->once();
+        $client->expects()->requestRaw($baseUri, 'GET', $params)->andReturn($response);
 
         $this->assertSame([
             'status' => $response->getStatusCode(),
@@ -119,7 +119,7 @@ class ClientTest extends TestCase
             'can_share' => $canShare,
             'scene' => $scene,
             'card_list' => $cardList,
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->createLandingPage($banner, $pageTitle, $canShare, $scene, $cardList));
     }
@@ -128,7 +128,7 @@ class ClientTest extends TestCase
     {
         $client = $this->mockApiClient(Client::class);
 
-        $client->expects()->httpPostJson('card/mpnews/gethtml', ['card_id' => 'mock-card-id'])->andReturn('mock-result')->once();
+        $client->expects()->httpPostJson('card/mpnews/gethtml', ['card_id' => 'mock-card-id'])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->getHtml('mock-card-id'));
     }
@@ -137,7 +137,7 @@ class ClientTest extends TestCase
     {
         $client = $this->mockApiClient(Client::class);
 
-        $client->expects()->httpPostJson('card/testwhitelist/set', ['openid' => ['mock-openid1', 'mock-openid2']])->andReturn('mock-result')->once();
+        $client->expects()->httpPostJson('card/testwhitelist/set', ['openid' => ['mock-openid1', 'mock-openid2']])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->setTestWhitelist(['mock-openid1', 'mock-openid2']));
     }
@@ -146,7 +146,7 @@ class ClientTest extends TestCase
     {
         $client = $this->mockApiClient(Client::class);
 
-        $client->expects()->httpPostJson('card/testwhitelist/set', ['username' => ['mock-username1', 'mock-username2']])->andReturn('mock-result')->once();
+        $client->expects()->httpPostJson('card/testwhitelist/set', ['username' => ['mock-username1', 'mock-username2']])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->setTestWhitelistByName(['mock-username1', 'mock-username2']));
     }
@@ -155,7 +155,7 @@ class ClientTest extends TestCase
     {
         $client = $this->mockApiClient(Client::class);
 
-        $client->expects()->httpPostJson('card/user/getcardlist', ['openid' => 'mock-openid', 'card_id' => 'mock-card-id'])->andReturn('mock-result')->once();
+        $client->expects()->httpPostJson('card/user/getcardlist', ['openid' => 'mock-openid', 'card_id' => 'mock-card-id'])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->getUserCards('mock-openid', 'mock-card-id'));
     }
@@ -164,7 +164,7 @@ class ClientTest extends TestCase
     {
         $client = $this->mockApiClient(Client::class);
 
-        $client->expects()->httpPostJson('card/get', ['card_id' => 'mock-card-id'])->andReturn('mock-result')->once();
+        $client->expects()->httpPostJson('card/get', ['card_id' => 'mock-card-id'])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->get('mock-card-id'));
     }
@@ -173,7 +173,7 @@ class ClientTest extends TestCase
     {
         $client = $this->mockApiClient(Client::class);
 
-        $client->expects()->httpPostJson('card/delete', ['card_id' => 'mock-card-id'])->andReturn('mock-result')->once();
+        $client->expects()->httpPostJson('card/delete', ['card_id' => 'mock-card-id'])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->delete('mock-card-id'));
     }
@@ -183,22 +183,22 @@ class ClientTest extends TestCase
         $client = $this->mockApiClient(Client::class);
 
         $client->expects()->httpPostJson('card/batchget', ['offset' => 0, 'count' => 10, 'status_list' => 'CARD_STATUS_VERIFY_OK'])
-            ->andReturn('mock-result')->once();
+            ->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->list());
 
         $client->expects()->httpPostJson('card/batchget', ['offset' => 1, 'count' => 10, 'status_list' => 'CARD_STATUS_VERIFY_OK'])
-            ->andReturn('mock-result')->once();
+            ->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->list(1));
 
         $client->expects()->httpPostJson('card/batchget', ['offset' => 1, 'count' => 10, 'status_list' => 'CARD_STATUS_VERIFY_OK'])
-            ->andReturn('mock-result')->once();
+            ->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->list(1, 10));
 
         $client->expects()->httpPostJson('card/batchget', ['offset' => 1, 'count' => 10, 'status_list' => 'CUSTOM'])
-            ->andReturn('mock-result')->once();
+            ->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->list(1, 10, 'CUSTOM'));
     }
@@ -233,7 +233,7 @@ class ClientTest extends TestCase
         $client->expects()->httpPostJson('card/update', [
             'card_id' => 'mock-card-id',
             'member_card' => [],
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->update('mock-card-id', 'member_card'));
 
@@ -241,7 +241,7 @@ class ClientTest extends TestCase
         $client->expects()->httpPostJson('card/update', [
             'card_id' => 'mock-card-id',
             'member_card' => $attributes,
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->update('mock-card-id', 'member_card', $attributes));
     }
@@ -250,10 +250,10 @@ class ClientTest extends TestCase
     {
         $client = $this->mockApiClient(Client::class);
 
-        $client->expects()->httpPostJson('card/paycell/set', ['card_id' => 'mock-card-id', 'is_open' => true])->andReturn('mock-result')->once();
+        $client->expects()->httpPostJson('card/paycell/set', ['card_id' => 'mock-card-id', 'is_open' => true])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->setPayCell('mock-card-id'));
 
-        $client->expects()->httpPostJson('card/paycell/set', ['card_id' => 'mock-card-id', 'is_open' => false])->andReturn('mock-result')->once();
+        $client->expects()->httpPostJson('card/paycell/set', ['card_id' => 'mock-card-id', 'is_open' => false])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->setPayCell('mock-card-id', false));
     }
 
@@ -261,7 +261,7 @@ class ClientTest extends TestCase
     {
         $client = $this->mockApiClient(Client::class, ['updateStock']);
 
-        $client->expects()->updateStock('mock-card-id', 10, 'increase')->andReturn('mock-result')->once();
+        $client->expects()->updateStock('mock-card-id', 10, 'increase')->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->increaseStock('mock-card-id', 10));
     }
@@ -270,7 +270,7 @@ class ClientTest extends TestCase
     {
         $client = $this->mockApiClient(Client::class, ['updateStock']);
 
-        $client->expects()->updateStock('mock-card-id', 10, 'reduce')->andReturn('mock-result')->once();
+        $client->expects()->updateStock('mock-card-id', 10, 'reduce')->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->reduceStock('mock-card-id', 10));
     }

--- a/tests/OfficialAccount/Card/CodeClientTest.php
+++ b/tests/OfficialAccount/Card/CodeClientTest.php
@@ -25,7 +25,7 @@ class CodeClientTest extends TestCase
             'card_id' => $cardId,
             'code' => ['code1', 'code2'],
         ];
-        $client->expects()->httpPostJson('card/code/deposit', $params)->andReturn('mock-result')->once();
+        $client->expects()->httpPostJson('card/code/deposit', $params)->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->deposit($cardId, ['code1', 'code2']));
     }
@@ -38,7 +38,7 @@ class CodeClientTest extends TestCase
         $params = [
             'card_id' => $cardId,
         ];
-        $client->expects()->httpPostJson('card/code/getdepositcount', $params)->andReturn('mock-result')->once();
+        $client->expects()->httpPostJson('card/code/getdepositcount', $params)->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->getDepositedCount($cardId));
     }
@@ -53,7 +53,7 @@ class CodeClientTest extends TestCase
             'card_id' => $cardId,
             'code' => ['code1', 'code2'],
         ];
-        $client->expects()->httpPostJson('card/code/checkcode', $params)->andReturn('mock-result')->once();
+        $client->expects()->httpPostJson('card/code/checkcode', $params)->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->check($cardId, ['code1', 'code2']));
     }
@@ -68,7 +68,7 @@ class CodeClientTest extends TestCase
             'code' => $code,
             'check_consume' => true,
             'card_id' => $cardId,
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->get($code, $cardId));
 
@@ -76,7 +76,7 @@ class CodeClientTest extends TestCase
             'code' => $code,
             'check_consume' => false,
             'card_id' => $cardId,
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->get($code, $cardId, false));
     }
@@ -93,7 +93,7 @@ class CodeClientTest extends TestCase
             'new_code' => $newCode,
             'card_id' => $cardId,
         ];
-        $client->expects()->httpPostJson('card/code/update', $params)->andReturn('mock-result')->once();
+        $client->expects()->httpPostJson('card/code/update', $params)->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->update($code, $newCode, $cardId));
     }
@@ -108,7 +108,7 @@ class CodeClientTest extends TestCase
             'code' => $code,
             'card_id' => $cardId,
         ];
-        $client->expects()->httpPostJson('card/code/unavailable', $params)->andReturn('mock-result')->once();
+        $client->expects()->httpPostJson('card/code/unavailable', $params)->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->disable($code, $cardId));
     }
@@ -120,10 +120,10 @@ class CodeClientTest extends TestCase
         $cardId = 'mock-card-id';
         $code = 'mock-code';
 
-        $client->expects()->httpPostJson('card/code/consume', ['code' => $code])->andReturn('mock-result')->once();
+        $client->expects()->httpPostJson('card/code/consume', ['code' => $code])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->consume($code));
 
-        $client->expects()->httpPostJson('card/code/consume', ['code' => $code, 'card_id' => $cardId])->andReturn('mock-result')->once();
+        $client->expects()->httpPostJson('card/code/consume', ['code' => $code, 'card_id' => $cardId])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->consume($code, $cardId));
     }
 
@@ -135,7 +135,7 @@ class CodeClientTest extends TestCase
         $params = [
             'encrypt_code' => $encryptedCode,
         ];
-        $client->expects()->httpPostJson('card/code/decrypt', $params)->andReturn('mock-result')->once();
+        $client->expects()->httpPostJson('card/code/decrypt', $params)->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->decrypt($encryptedCode));
     }

--- a/tests/OfficialAccount/Card/CoinClientTest.php
+++ b/tests/OfficialAccount/Card/CoinClientTest.php
@@ -20,7 +20,7 @@ class CoinClientTest extends TestCase
     {
         $client = $this->mockApiClient(CoinClient::class);
 
-        $client->expects()->httpGet('card/pay/activate')->andReturn('mock-result')->once();
+        $client->expects()->httpGet('card/pay/activate')->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->activate());
     }
@@ -29,7 +29,7 @@ class CoinClientTest extends TestCase
     {
         $client = $this->mockApiClient(CoinClient::class);
 
-        $client->expects()->httpGet('card/pay/getcoinsinfo')->andReturn('mock-result')->once();
+        $client->expects()->httpGet('card/pay/getcoinsinfo')->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->summary());
     }
@@ -44,7 +44,7 @@ class CoinClientTest extends TestCase
             'card_id' => $cardId,
             'quantity' => $quantity,
         ];
-        $client->expects()->httpPostJson('card/pay/getpayprice', $params)->andReturn('mock-result')->once();
+        $client->expects()->httpPostJson('card/pay/getpayprice', $params)->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->getPrice($cardId, $quantity));
     }
@@ -55,7 +55,7 @@ class CoinClientTest extends TestCase
 
         $client->expects()->httpPostJson('card/pay/recharge', [
             'coin_count' => 100,
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->recharge(100));
     }
@@ -66,7 +66,7 @@ class CoinClientTest extends TestCase
 
         $client->expects()->httpPostJson('card/pay/getorder', [
             'order_id' => 'mock-order-id',
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->order('mock-order-id'));
     }
@@ -75,7 +75,7 @@ class CoinClientTest extends TestCase
     {
         $client = $this->mockApiClient(CoinClient::class);
 
-        $client->expects()->httpPostJson('card/pay/getorderlist', ['foo' => 'bar'])->andReturn('mock-result')->once();
+        $client->expects()->httpPostJson('card/pay/getorderlist', ['foo' => 'bar'])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->orders(['foo' => 'bar']));
     }
@@ -88,7 +88,7 @@ class CoinClientTest extends TestCase
             'card_id' => 'mock-card-id',
             'order_id' => 'mock-order-id',
             'quantity' => 20,
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->confirm('mock-card-id', 'mock-order-id', 20));
     }

--- a/tests/OfficialAccount/Card/GeneralCardClientTest.php
+++ b/tests/OfficialAccount/Card/GeneralCardClientTest.php
@@ -23,7 +23,7 @@ class GeneralCardClientTest extends TestCase
         $params = [
             'foo' => 'bar',
         ];
-        $client->expects()->httpPostJson('card/generalcard/activate', $params)->andReturn('mock-result')->once();
+        $client->expects()->httpPostJson('card/generalcard/activate', $params)->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->activate($params));
     }
@@ -36,7 +36,7 @@ class GeneralCardClientTest extends TestCase
             'card_id' => 'mock-card-id',
             'code' => 'bar',
         ];
-        $client->expects()->httpPostJson('card/generalcard/unactivate', $params)->andReturn('mock-result')->once();
+        $client->expects()->httpPostJson('card/generalcard/unactivate', $params)->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->deactivate('mock-card-id', 'bar'));
     }
@@ -45,7 +45,7 @@ class GeneralCardClientTest extends TestCase
     {
         $client = $this->mockApiClient(GeneralCardClient::class);
 
-        $client->expects()->httpPostJson('card/generalcard/updateuser', ['foo' => 'bar'])->andReturn('mock-result')->once();
+        $client->expects()->httpPostJson('card/generalcard/updateuser', ['foo' => 'bar'])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->updateUser(['foo' => 'bar']));
     }

--- a/tests/OfficialAccount/Card/JssdkClientTest.php
+++ b/tests/OfficialAccount/Card/JssdkClientTest.php
@@ -35,7 +35,7 @@ class JssdkClientTest extends TestCase
         $cache->expects()->has($cacheKey)->twice()->andReturns(false, true);
         $cache->expects()->get($cacheKey)->never();
         $cache->expects()->set($cacheKey, $ticket, $ticket['expires_in'] - 500);
-        $client->expects()->requestRaw('https://api.weixin.qq.com/cgi-bin/ticket/getticket', 'GET', ['query' => ['type' => 'wx_card']])->andReturn($response)->once();
+        $client->expects()->requestRaw('https://api.weixin.qq.com/cgi-bin/ticket/getticket', 'GET', ['query' => ['type' => 'wx_card']])->andReturn($response);
 
         $this->assertSame($ticket, $client->getTicket());
     }
@@ -57,14 +57,14 @@ class JssdkClientTest extends TestCase
         ])->andReturn([
             'card_id' => 'mock-card-id1',
             'assigned' => 'yes',
-        ])->once();
+        ]);
 
         $client->expects()->attachExtension('mock-card-id2', [
             'card_id' => 'mock-card-id2',
         ])->andReturn([
             'card_id' => 'mock-card-id2',
             'assigned' => 'yes',
-        ])->once();
+        ]);
 
         $this->assertSame(json_encode([
             [
@@ -93,7 +93,7 @@ class JssdkClientTest extends TestCase
         ];
 
         $client->expects()->dictionaryOrderSignature('mock-ticket', \Mockery::type('int'), 'mock-card-id', 'mock-code', 'mock-openid', \Mockery::type('string'))
-                    ->andReturn('mock-signature')->once();
+                    ->andReturn('mock-signature');
         $client->expects()->getTicket()->andReturn(['ticket' => 'mock-ticket']);
 
         $attached = $client->attachExtension('mock-card-id', $card);

--- a/tests/OfficialAccount/Card/MeetingTicketClientTest.php
+++ b/tests/OfficialAccount/Card/MeetingTicketClientTest.php
@@ -23,7 +23,7 @@ class MeetingTicketClientTest extends TestCase
         $params = [
             'foo' => 'bar',
         ];
-        $client->expects()->httpPostJson('card/meetingticket/updateuser', $params)->andReturn('mock-result')->once();
+        $client->expects()->httpPostJson('card/meetingticket/updateuser', $params)->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->updateUser($params));
     }

--- a/tests/OfficialAccount/Card/MemberCardClientTest.php
+++ b/tests/OfficialAccount/Card/MemberCardClientTest.php
@@ -23,7 +23,7 @@ class MemberCardClientTest extends TestCase
         $params = [
             'foo' => 'bar',
         ];
-        $client->expects()->httpPostJson('card/membercard/activate', $params)->andReturn('mock-result')->once();
+        $client->expects()->httpPostJson('card/membercard/activate', $params)->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->activate($params));
     }
@@ -36,7 +36,7 @@ class MemberCardClientTest extends TestCase
             'card_id' => 'mock-card-id',
             'foo' => 'bar',
         ];
-        $client->expects()->httpPostJson('card/membercard/activateuserform/set', $params)->andReturn('mock-result')->once();
+        $client->expects()->httpPostJson('card/membercard/activateuserform/set', $params)->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->setActivationForm('mock-card-id', $params));
     }
@@ -48,7 +48,7 @@ class MemberCardClientTest extends TestCase
         $params = [
             'activate_ticket' => 'mock-activate-ticket',
         ];
-        $client->expects()->httpPostJson('card/membercard/activatetempinfo/get', $params)->andReturn('mock-result')->once();
+        $client->expects()->httpPostJson('card/membercard/activatetempinfo/get', $params)->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->getActivationForm('mock-activate-ticket'));
     }
@@ -61,7 +61,7 @@ class MemberCardClientTest extends TestCase
             'card_id' => 'mock-card-id',
             'code' => 'mock-code',
         ];
-        $client->expects()->httpPostJson('card/membercard/userinfo/get', $params)->andReturn('mock-result')->once();
+        $client->expects()->httpPostJson('card/membercard/userinfo/get', $params)->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->getUser('mock-card-id', 'mock-code'));
     }
@@ -70,7 +70,7 @@ class MemberCardClientTest extends TestCase
     {
         $client = $this->mockApiClient(MemberCardClient::class);
 
-        $client->expects()->httpPostJson('card/membercard/updateuser', ['foo' => 'bar'])->andReturn('mock-result')->once();
+        $client->expects()->httpPostJson('card/membercard/updateuser', ['foo' => 'bar'])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->updateUser(['foo' => 'bar']));
     }
@@ -84,7 +84,7 @@ class MemberCardClientTest extends TestCase
             'outer_str' => 'mock-outer_str',
         ];
 
-        $client->expects()->httpPostJson('card/membercard/activate/geturl', $params)->andReturn('mock-result')->once();
+        $client->expects()->httpPostJson('card/membercard/activate/geturl', $params)->andReturn('mock-result');
         $this->assertSame('mock-result', $client->getActivateUrl($params));
     }
 }

--- a/tests/OfficialAccount/Card/MovieTicketClientTest.php
+++ b/tests/OfficialAccount/Card/MovieTicketClientTest.php
@@ -20,7 +20,7 @@ class MovieTicketClientTest extends TestCase
     {
         $client = $this->mockApiClient(MovieTicketClient::class);
 
-        $client->expects()->httpPostJson('card/movieticket/updateuser', ['foo' => 'bar'])->andReturn('mock-result')->once();
+        $client->expects()->httpPostJson('card/movieticket/updateuser', ['foo' => 'bar'])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->updateUser(['foo' => 'bar']));
     }

--- a/tests/OfficialAccount/Card/SubMerchantClientTest.php
+++ b/tests/OfficialAccount/Card/SubMerchantClientTest.php
@@ -34,7 +34,7 @@ class SubMerchantClientTest extends TestCase
             'foo' => 'bar',
         ];
 
-        $client->expects()->httpPostJson('card/submerchant/submit', ['info' => Arr::except($info, 'foo')])->andReturn('mock-result')->once();
+        $client->expects()->httpPostJson('card/submerchant/submit', ['info' => Arr::except($info, 'foo')])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->create($info));
     }
@@ -58,7 +58,7 @@ class SubMerchantClientTest extends TestCase
 
         $client->expects()->httpPostJson('card/submerchant/update', [
             'info' => array_merge(['merchant_id' => 13], Arr::except($info, 'foo')),
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->update(13, $info));
     }
@@ -67,7 +67,7 @@ class SubMerchantClientTest extends TestCase
     {
         $client = $this->mockApiClient(SubMerchantClient::class);
 
-        $client->expects()->httpPostJson('card/submerchant/get', ['merchant_id' => 13])->andReturn('mock-result')->once();
+        $client->expects()->httpPostJson('card/submerchant/get', ['merchant_id' => 13])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->get(13));
     }
@@ -80,7 +80,7 @@ class SubMerchantClientTest extends TestCase
             'begin_id' => 0,
             'limit' => 50,
             'status' => 'CHECKING',
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->list());
 
@@ -88,7 +88,7 @@ class SubMerchantClientTest extends TestCase
             'begin_id' => 10,
             'limit' => 20,
             'status' => 'CHECKED',
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->list(10, 20, 'CHECKED'));
     }

--- a/tests/OfficialAccount/Comment/ClientTest.php
+++ b/tests/OfficialAccount/Comment/ClientTest.php
@@ -23,7 +23,7 @@ class ClientTest extends TestCase
         $client->expects()->httpPostJson('cgi-bin/comment/open', [
             'msg_data_id' => 'mock-id',
             'index' => 1,
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->open('mock-id', 1));
     }
@@ -35,7 +35,7 @@ class ClientTest extends TestCase
         $client->expects()->httpPostJson('cgi-bin/comment/close', [
             'msg_data_id' => 'mock-id',
             'index' => 2,
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->close('mock-id', 2));
     }
@@ -50,7 +50,7 @@ class ClientTest extends TestCase
             'begin' => 0,
             'count' => 20,
             'type' => 1,
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->list('mock-id', 3, 0, 20, 1));
     }
@@ -63,7 +63,7 @@ class ClientTest extends TestCase
             'msg_data_id' => 'mock-id',
             'index' => 3,
             'user_comment_id' => 18,
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->markElect('mock-id', 3, 18));
     }
@@ -76,7 +76,7 @@ class ClientTest extends TestCase
             'msg_data_id' => 'mock-id',
             'index' => 3,
             'user_comment_id' => 18,
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->unmarkElect('mock-id', 3, 18));
     }
@@ -89,7 +89,7 @@ class ClientTest extends TestCase
             'msg_data_id' => 'mock-id',
             'index' => 3,
             'user_comment_id' => 18,
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->delete('mock-id', 3, 18));
     }
@@ -103,7 +103,7 @@ class ClientTest extends TestCase
             'index' => 3,
             'user_comment_id' => 18,
             'content' => 'mock-content',
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->reply('mock-id', 3, 18, 'mock-content'));
     }
@@ -116,7 +116,7 @@ class ClientTest extends TestCase
             'msg_data_id' => 'mock-id',
             'index' => 3,
             'user_comment_id' => 18,
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->deleteReply('mock-id', 3, 18));
     }

--- a/tests/OfficialAccount/CustomerService/ClientTest.php
+++ b/tests/OfficialAccount/CustomerService/ClientTest.php
@@ -21,7 +21,7 @@ class ClientTest extends TestCase
     {
         $client = $this->mockApiClient(Client::class);
 
-        $client->expects()->httpGet('cgi-bin/customservice/getkflist')->andReturn('mock-result')->once();
+        $client->expects()->httpGet('cgi-bin/customservice/getkflist')->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->list());
     }
@@ -30,7 +30,7 @@ class ClientTest extends TestCase
     {
         $client = $this->mockApiClient(Client::class);
 
-        $client->expects()->httpGet('cgi-bin/customservice/getonlinekflist')->andReturn('mock-result')->once();
+        $client->expects()->httpGet('cgi-bin/customservice/getonlinekflist')->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->online());
     }
@@ -42,7 +42,7 @@ class ClientTest extends TestCase
         $client->expects()->httpPostJson('customservice/kfaccount/add', [
             'kf_account' => 'overtrue@test',
             'nickname' => '小超',
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->create('overtrue@test', '小超'));
     }
@@ -54,7 +54,7 @@ class ClientTest extends TestCase
         $client->expects()->httpPostJson('customservice/kfaccount/update', [
             'kf_account' => 'overtrue@test',
             'nickname' => '小小超',
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->update('overtrue@test', '小小超'));
     }
@@ -64,7 +64,7 @@ class ClientTest extends TestCase
         $client = $this->mockApiClient(Client::class);
 
         $client->expects()->httpPostJson('customservice/kfaccount/del', [], ['kf_account' => 'overtrue@test'])
-            ->andReturn('mock-result')->once();
+            ->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->delete('overtrue@test'));
     }
@@ -76,7 +76,7 @@ class ClientTest extends TestCase
         $client->expects()->httpPostJson('customservice/kfaccount/inviteworker', [
             'kf_account' => 'overtrue@test',
             'invite_wx' => 'notovertrue',
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->invite('overtrue@test', 'notovertrue'));
     }
@@ -90,7 +90,7 @@ class ClientTest extends TestCase
             ['media' => '/path/to/image.jpg'],
             [],
             ['kf_account' => 'overtrue@test']
-        )->andReturn('mock-result')->once();
+        )->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->setAvatar('overtrue@test', '/path/to/image.jpg'));
     }
@@ -106,7 +106,7 @@ class ClientTest extends TestCase
     {
         $client = $this->mockApiClient(Client::class);
 
-        $client->expects()->httpPostJson('cgi-bin/message/custom/send', ['foo' => 'bar'])->andReturn('mock-result')->once();
+        $client->expects()->httpPostJson('cgi-bin/message/custom/send', ['foo' => 'bar'])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->send(['foo' => 'bar']));
     }
@@ -118,7 +118,7 @@ class ClientTest extends TestCase
         $client->expects()->httpPostJson('cgi-bin/message/custom/typing', [
             'touser' => 'open-id',
             'command' => 'Typing',
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->showTypingStatusToUser('open-id'));
     }
@@ -130,7 +130,7 @@ class ClientTest extends TestCase
         $client->expects()->httpPostJson('cgi-bin/message/custom/typing', [
             'touser' => 'open-id',
             'command' => 'CancelTyping',
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->hideTypingStatusToUser('open-id'));
     }
@@ -144,7 +144,7 @@ class ClientTest extends TestCase
             'endtime' => 1464796800,
             'msgid' => 1,
             'number' => 10000,
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->messages(1464710400, 1464796800));
 
         $client->expects()->httpPostJson('customservice/msgrecord/getmsglist', [
@@ -152,7 +152,7 @@ class ClientTest extends TestCase
             'endtime' => 1464796800,
             'msgid' => 2,
             'number' => 100,
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->messages(1464710400, 1464796800, 2, 100));
 
         // string time
@@ -161,7 +161,7 @@ class ClientTest extends TestCase
             'endtime' => strtotime('2017-08-05 12:01:00'),
             'msgid' => 2,
             'number' => 100,
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->messages('2017-08-05 12:00:00', '2017-08-05 12:01:00', 2, 100));
     }
 }

--- a/tests/OfficialAccount/CustomerService/SessionClientTest.php
+++ b/tests/OfficialAccount/CustomerService/SessionClientTest.php
@@ -22,7 +22,7 @@ class SessionClientTest extends TestCase
 
         $client->expects()->httpGet('customservice/kfsession/getsessionlist', [
             'kf_account' => 'overtrue@test',
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->list('overtrue@test'));
     }
@@ -31,7 +31,7 @@ class SessionClientTest extends TestCase
     {
         $client = $this->mockApiClient(SessionClient::class);
 
-        $client->expects()->httpGet('customservice/kfsession/getwaitcase')->andReturn('mock-result')->once();
+        $client->expects()->httpGet('customservice/kfsession/getwaitcase')->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->waiting());
     }
@@ -43,7 +43,7 @@ class SessionClientTest extends TestCase
         $client->expects()->httpPostJson('customservice/kfsession/create', [
             'kf_account' => 'overtrue@test',
             'openid' => 'mock-openid',
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->create('overtrue@test', 'mock-openid'));
     }
@@ -55,7 +55,7 @@ class SessionClientTest extends TestCase
         $client->expects()->httpPostJson('customservice/kfsession/close', [
             'kf_account' => 'overtrue@test',
             'openid' => 'mock-openid',
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->close('overtrue@test', 'mock-openid'));
     }
@@ -66,7 +66,7 @@ class SessionClientTest extends TestCase
 
         $client->expects()->httpGet('customservice/kfsession/getsession', [
             'openid' => 'mock-openid',
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->get('mock-openid'));
     }

--- a/tests/OfficialAccount/DataCube/ClientTest.php
+++ b/tests/OfficialAccount/DataCube/ClientTest.php
@@ -20,7 +20,7 @@ class ClientTest extends TestCase
     {
         $client = $this->mockApiClient(Client::class, ['query']);
 
-        $client->expects()->query('datacube/getusersummary', '2017-08-02', '2017-08-10')->andReturn('mock-result')->once();
+        $client->expects()->query('datacube/getusersummary', '2017-08-02', '2017-08-10')->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->userSummary('2017-08-02', '2017-08-10'));
     }
@@ -29,7 +29,7 @@ class ClientTest extends TestCase
     {
         $client = $this->mockApiClient(Client::class, ['query']);
 
-        $client->expects()->query('datacube/getusercumulate', '2017-08-02', '2017-08-10')->andReturn('mock-result')->once();
+        $client->expects()->query('datacube/getusercumulate', '2017-08-02', '2017-08-10')->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->userCumulate('2017-08-02', '2017-08-10'));
     }
@@ -38,7 +38,7 @@ class ClientTest extends TestCase
     {
         $client = $this->mockApiClient(Client::class, ['query']);
 
-        $client->expects()->query('datacube/getarticlesummary', '2017-08-02', '2017-08-10')->andReturn('mock-result')->once();
+        $client->expects()->query('datacube/getarticlesummary', '2017-08-02', '2017-08-10')->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->articleSummary('2017-08-02', '2017-08-10'));
     }
@@ -47,7 +47,7 @@ class ClientTest extends TestCase
     {
         $client = $this->mockApiClient(Client::class, ['query']);
 
-        $client->expects()->query('datacube/getarticletotal', '2017-08-02', '2017-08-10')->andReturn('mock-result')->once();
+        $client->expects()->query('datacube/getarticletotal', '2017-08-02', '2017-08-10')->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->articleTotal('2017-08-02', '2017-08-10'));
     }
@@ -56,7 +56,7 @@ class ClientTest extends TestCase
     {
         $client = $this->mockApiClient(Client::class, ['query']);
 
-        $client->expects()->query('datacube/getuserread', '2017-08-02', '2017-08-10')->andReturn('mock-result')->once();
+        $client->expects()->query('datacube/getuserread', '2017-08-02', '2017-08-10')->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->userReadSummary('2017-08-02', '2017-08-10'));
     }
@@ -65,7 +65,7 @@ class ClientTest extends TestCase
     {
         $client = $this->mockApiClient(Client::class, ['query']);
 
-        $client->expects()->query('datacube/getuserreadhour', '2017-08-02', '2017-08-10')->andReturn('mock-result')->once();
+        $client->expects()->query('datacube/getuserreadhour', '2017-08-02', '2017-08-10')->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->userReadHourly('2017-08-02', '2017-08-10'));
     }
@@ -74,7 +74,7 @@ class ClientTest extends TestCase
     {
         $client = $this->mockApiClient(Client::class, ['query']);
 
-        $client->expects()->query('datacube/getusershare', '2017-08-02', '2017-08-10')->andReturn('mock-result')->once();
+        $client->expects()->query('datacube/getusershare', '2017-08-02', '2017-08-10')->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->userShareSummary('2017-08-02', '2017-08-10'));
     }
@@ -83,7 +83,7 @@ class ClientTest extends TestCase
     {
         $client = $this->mockApiClient(Client::class, ['query']);
 
-        $client->expects()->query('datacube/getusersharehour', '2017-08-02', '2017-08-10')->andReturn('mock-result')->once();
+        $client->expects()->query('datacube/getusersharehour', '2017-08-02', '2017-08-10')->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->userShareHourly('2017-08-02', '2017-08-10'));
     }
@@ -92,7 +92,7 @@ class ClientTest extends TestCase
     {
         $client = $this->mockApiClient(Client::class, ['query']);
 
-        $client->expects()->query('datacube/getupstreammsg', '2017-08-02', '2017-08-10')->andReturn('mock-result')->once();
+        $client->expects()->query('datacube/getupstreammsg', '2017-08-02', '2017-08-10')->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->upstreamMessageSummary('2017-08-02', '2017-08-10'));
     }
@@ -101,7 +101,7 @@ class ClientTest extends TestCase
     {
         $client = $this->mockApiClient(Client::class, ['query']);
 
-        $client->expects()->query('datacube/getupstreammsghour', '2017-08-02', '2017-08-10')->andReturn('mock-result')->once();
+        $client->expects()->query('datacube/getupstreammsghour', '2017-08-02', '2017-08-10')->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->upstreamMessageHourly('2017-08-02', '2017-08-10'));
     }
@@ -110,7 +110,7 @@ class ClientTest extends TestCase
     {
         $client = $this->mockApiClient(Client::class, ['query']);
 
-        $client->expects()->query('datacube/getupstreammsgweek', '2017-08-02', '2017-08-10')->andReturn('mock-result')->once();
+        $client->expects()->query('datacube/getupstreammsgweek', '2017-08-02', '2017-08-10')->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->upstreamMessageWeekly('2017-08-02', '2017-08-10'));
     }
@@ -119,7 +119,7 @@ class ClientTest extends TestCase
     {
         $client = $this->mockApiClient(Client::class, ['query']);
 
-        $client->expects()->query('datacube/getupstreammsgmonth', '2017-08-02', '2017-08-10')->andReturn('mock-result')->once();
+        $client->expects()->query('datacube/getupstreammsgmonth', '2017-08-02', '2017-08-10')->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->upstreamMessageMonthly('2017-08-02', '2017-08-10'));
     }
@@ -128,7 +128,7 @@ class ClientTest extends TestCase
     {
         $client = $this->mockApiClient(Client::class, ['query']);
 
-        $client->expects()->query('datacube/getupstreammsgdist', '2017-08-02', '2017-08-10')->andReturn('mock-result')->once();
+        $client->expects()->query('datacube/getupstreammsgdist', '2017-08-02', '2017-08-10')->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->upstreamMessageDistSummary('2017-08-02', '2017-08-10'));
     }
@@ -137,7 +137,7 @@ class ClientTest extends TestCase
     {
         $client = $this->mockApiClient(Client::class, ['query']);
 
-        $client->expects()->query('datacube/getupstreammsgdistweek', '2017-08-02', '2017-08-10')->andReturn('mock-result')->once();
+        $client->expects()->query('datacube/getupstreammsgdistweek', '2017-08-02', '2017-08-10')->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->upstreamMessageDistWeekly('2017-08-02', '2017-08-10'));
     }
@@ -146,7 +146,7 @@ class ClientTest extends TestCase
     {
         $client = $this->mockApiClient(Client::class, ['query']);
 
-        $client->expects()->query('datacube/getupstreammsgdistmonth', '2017-08-02', '2017-08-10')->andReturn('mock-result')->once();
+        $client->expects()->query('datacube/getupstreammsgdistmonth', '2017-08-02', '2017-08-10')->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->upstreamMessageDistMonthly('2017-08-02', '2017-08-10'));
     }
@@ -155,7 +155,7 @@ class ClientTest extends TestCase
     {
         $client = $this->mockApiClient(Client::class, ['query']);
 
-        $client->expects()->query('datacube/getinterfacesummary', '2017-08-02', '2017-08-10')->andReturn('mock-result')->once();
+        $client->expects()->query('datacube/getinterfacesummary', '2017-08-02', '2017-08-10')->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->interfaceSummary('2017-08-02', '2017-08-10'));
     }
@@ -164,7 +164,7 @@ class ClientTest extends TestCase
     {
         $client = $this->mockApiClient(Client::class, ['query']);
 
-        $client->expects()->query('datacube/getinterfacesummaryhour', '2017-08-02', '2017-08-10')->andReturn('mock-result')->once();
+        $client->expects()->query('datacube/getinterfacesummaryhour', '2017-08-02', '2017-08-10')->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->interfaceSummaryHourly('2017-08-02', '2017-08-10'));
     }
@@ -175,7 +175,7 @@ class ClientTest extends TestCase
 
         $client->expects()->query('datacube/getcardbizuininfo', '2017-08-02', '2017-08-10', [
             'cond_source' => 67,
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->cardSummary('2017-08-02', '2017-08-10', '67'));
     }
@@ -187,7 +187,7 @@ class ClientTest extends TestCase
         $client->expects()->query('datacube/getcardcardinfo', '2017-08-02', '2017-08-10', [
             'cond_source' => 67,
             'card_id' => 'mock-card_id',
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->freeCardSummary('2017-08-02', '2017-08-10', '67', 'mock-card_id'));
     }
@@ -198,7 +198,7 @@ class ClientTest extends TestCase
 
         $client->expects()->query('datacube/getcardmembercardinfo', '2017-08-02', '2017-08-10', [
             'cond_source' => 67,
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->memberCardSummary('2017-08-02', '2017-08-10', '67'));
     }
@@ -209,7 +209,7 @@ class ClientTest extends TestCase
 
         $client->expects()->query('datacube/getcardmembercarddetail', '2017-08-02', '2017-08-10', [
             'card_id' => 'mock-card_id',
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->memberCardSummaryById('2017-08-02', '2017-08-10', 'mock-card_id'));
     }
@@ -222,7 +222,7 @@ class ClientTest extends TestCase
             'begin_date' => '2017-08-02',
             'end_date' => '2017-08-10',
             'foo' => 'bar',
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->query('path/to/api', '2017-08-02', '2017-08-10', ['foo' => 'bar']));
     }

--- a/tests/OfficialAccount/Device/ClientTest.php
+++ b/tests/OfficialAccount/Device/ClientTest.php
@@ -35,7 +35,7 @@ class ClientTest extends TestCase
             'device_id' => 'mock-id',
             'open_id' => 'mock-openid',
             'content' => base64_encode('hello'),
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->message('mock-id', 'mock-openid', 'hello'));
     }
@@ -47,7 +47,7 @@ class ClientTest extends TestCase
         $client->expects()->httpPostJson('device/create_qrcode', [
             'device_num' => 2,
             'device_id_list' => ['mock-id1', 'mock-id2'],
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->qrCode(['mock-id1', 'mock-id2']));
     }
@@ -58,7 +58,7 @@ class ClientTest extends TestCase
 
         $client->expects()->httpGet('device/getqrcode', [
             'product_id' => 'mock-pid',
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->createId('mock-pid'));
     }
@@ -71,7 +71,7 @@ class ClientTest extends TestCase
             'ticket' => 'mock-ticket',
             'device_id' => 'mock-id',
             'openid' => 'mock-openid',
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->bind('mock-openid', 'mock-id', 'mock-ticket'));
     }
@@ -84,7 +84,7 @@ class ClientTest extends TestCase
             'ticket' => 'mock-ticket',
             'device_id' => 'mock-id',
             'openid' => 'mock-openid',
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->unbind('mock-openid', 'mock-id', 'mock-ticket'));
     }
@@ -96,7 +96,7 @@ class ClientTest extends TestCase
         $client->expects()->httpPostJson('device/compel_bind', [
             'device_id' => 'mock-id',
             'openid' => 'mock-openid',
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->forceBind('mock-openid', 'mock-id'));
     }
@@ -108,7 +108,7 @@ class ClientTest extends TestCase
         $client->expects()->httpPostJson('device/compel_unbind', [
             'device_id' => 'mock-id',
             'openid' => 'mock-openid',
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->forceUnbind('mock-openid', 'mock-id'));
     }
@@ -119,7 +119,7 @@ class ClientTest extends TestCase
 
         $client->expects()->httpGet('device/get_stat', [
             'device_id' => 'mock-id',
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->status('mock-id'));
     }
@@ -130,7 +130,7 @@ class ClientTest extends TestCase
 
         $client->expects()->httpPost('device/verify_qrcode', [
             'ticket' => 'mock-ticket',
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->verify('mock-ticket'));
     }
@@ -142,7 +142,7 @@ class ClientTest extends TestCase
         $client->expects()->httpGet('device/get_openid', [
             'device_id' => 'mock-id',
             'device_type' => 'mock-type',
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->openid('mock-id'));
     }
@@ -153,7 +153,7 @@ class ClientTest extends TestCase
 
         $client->expects()->httpGet('device/get_bind_device', [
             'openid' => 'mock-openid',
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->listByOpenid('mock-openid'));
     }
@@ -196,7 +196,7 @@ class ClientTest extends TestCase
             'device_list' => $devices,
             'op_type' => 0,
             'product_id' => 'mock-pid',
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->authorize($devices, 'mock-pid'));
     }
 }

--- a/tests/OfficialAccount/Material/ClientTest.php
+++ b/tests/OfficialAccount/Material/ClientTest.php
@@ -24,7 +24,7 @@ class ClientTest extends TestCase
     {
         $client = $this->mockApiClient(Client::class, ['upload']);
 
-        $client->expects()->upload('image', '/path/to/media')->andReturn('mock-result')->once();
+        $client->expects()->upload('image', '/path/to/media')->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->uploadImage('/path/to/media'));
     }
@@ -33,7 +33,7 @@ class ClientTest extends TestCase
     {
         $client = $this->mockApiClient(Client::class, ['upload']);
 
-        $client->expects()->upload('voice', '/path/to/media')->andReturn('mock-result')->once();
+        $client->expects()->upload('voice', '/path/to/media')->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->uploadVoice('/path/to/media'));
     }
@@ -42,7 +42,7 @@ class ClientTest extends TestCase
     {
         $client = $this->mockApiClient(Client::class, ['upload']);
 
-        $client->expects()->upload('thumb', '/path/to/media')->andReturn('mock-result')->once();
+        $client->expects()->upload('thumb', '/path/to/media')->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->uploadThumb('/path/to/media'));
     }
@@ -56,7 +56,7 @@ class ClientTest extends TestCase
                'title' => 'mock-title',
                 'introduction' => 'mock-introduction',
             ]),
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->uploadVideo('/path/to/media', 'mock-title', 'mock-introduction'));
     }
@@ -91,7 +91,7 @@ class ClientTest extends TestCase
             'articles' => [
                 $article1->all(),
             ],
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->uploadArticle($article1->all()));
 
         // case2: Article
@@ -99,7 +99,7 @@ class ClientTest extends TestCase
             'articles' => [
                 $article1->transformForJsonRequestWithoutType([]),
             ],
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->uploadArticle($article1));
 
         // case3: [Article, Article]
@@ -108,7 +108,7 @@ class ClientTest extends TestCase
                 $article1->transformForJsonRequestWithoutType(),
                 $article2->transformForJsonRequestWithoutType(),
             ],
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->uploadArticle([$article1, $article2]));
     }
 
@@ -131,7 +131,7 @@ class ClientTest extends TestCase
             'media_id' => 'mock-media-id',
             'index' => 3,
             'articles' => $article->transformForJsonRequestWithoutType(),
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->updateArticle('mock-media-id', $article, 3));
 
         // case2: Article array
@@ -139,7 +139,7 @@ class ClientTest extends TestCase
             'media_id' => 'mock-media-id',
             'index' => 3,
             'articles' => $article->all(),
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->updateArticle('mock-media-id', $article->all(), 3));
     }
 
@@ -147,7 +147,7 @@ class ClientTest extends TestCase
     {
         $client = $this->mockApiClient(Client::class, ['upload']);
 
-        $client->expects()->upload('news_image', '/path/to/media')->andReturn('mock-result')->once();
+        $client->expects()->upload('news_image', '/path/to/media')->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->uploadArticleImage('/path/to/media'));
     }
@@ -159,14 +159,14 @@ class ClientTest extends TestCase
         // stream response
         $response = new Response(200, ['Content-Disposition' => 'attachment; filename="filename.jpg"'], 'mock-content');
         $client->expects()->requestRaw('cgi-bin/material/get_material', 'POST', ['json' => ['media_id' => 'mock-media-id']])
-                    ->andReturn($response)->once();
+                    ->andReturn($response);
 
         $this->assertInstanceOf(StreamResponse::class, $client->get('mock-media-id'));
 
         // json response
         $response = new Response(200, ['Content-Type' => ['text/plain']], '{"title": "mock-title"}');
         $client->expects()->requestRaw('cgi-bin/material/get_material', 'POST', ['json' => ['media_id' => 'mock-media-id']])
-                    ->andReturn($response)->once();
+                    ->andReturn($response);
 
         $result = $client->get('mock-media-id');
         $this->assertInternalType('array', $result);
@@ -177,7 +177,7 @@ class ClientTest extends TestCase
         $client = $this->mockApiClient(Client::class);
 
         $client->expects()->httpPostJson('cgi-bin/material/del_material', ['media_id' => 'mock-media-id'])
-                ->andReturn('mock-result')->once();
+                ->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->delete('mock-media-id'));
     }
@@ -190,21 +190,21 @@ class ClientTest extends TestCase
             'type' => 'image',
             'offset' => 0,
             'count' => 20,
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->list('image'));
 
         $client->expects()->httpPostJson('cgi-bin/material/batchget_material', [
             'type' => 'image',
             'offset' => 1,
             'count' => 20,
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->list('image', 1));
 
         $client->expects()->httpPostJson('cgi-bin/material/batchget_material', [
             'type' => 'image',
             'offset' => 1,
             'count' => 10,
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->list('image', 1, 10));
     }
 
@@ -213,7 +213,7 @@ class ClientTest extends TestCase
         $client = $this->mockApiClient(Client::class);
 
         $client->expects()->httpGet('cgi-bin/material/get_materialcount')
-                            ->andReturn('mock-result')->once();
+                            ->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->stats());
     }
@@ -235,12 +235,12 @@ class ClientTest extends TestCase
         // real path
         $path = STUBS_ROOT.'/files/image.jpg';
         $client->expects()->httpUpload('cgi-bin/material/add_material', ['media' => $path], ['foo' => 'bar', 'type' => 'image'])
-                    ->andReturn('mock-result')->once();
+                    ->andReturn('mock-result');
         $this->assertSame('mock-result', $client->upload('image', $path, ['foo' => 'bar']));
 
         // real path with news image
         $client->expects()->httpUpload('cgi-bin/media/uploadimg', ['media' => $path], ['foo' => 'bar', 'type' => 'news_image'])
-            ->andReturn('mock-result')->once();
+            ->andReturn('mock-result');
         $this->assertSame('mock-result', $client->upload('news_image', $path, ['foo' => 'bar']));
     }
 }

--- a/tests/OfficialAccount/Menu/ClientTest.php
+++ b/tests/OfficialAccount/Menu/ClientTest.php
@@ -19,7 +19,7 @@ class ClientTest extends TestCase
     public function testList()
     {
         $client = $this->mockApiClient(Client::class);
-        $client->expects()->httpGet('cgi-bin/menu/get')->andReturn('mock-result')->once();
+        $client->expects()->httpGet('cgi-bin/menu/get')->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->list());
     }
@@ -27,7 +27,7 @@ class ClientTest extends TestCase
     public function testCurrent()
     {
         $client = $this->mockApiClient(Client::class);
-        $client->expects()->httpGet('cgi-bin/get_current_selfmenu_info')->andReturn('mock-result')->once();
+        $client->expects()->httpGet('cgi-bin/get_current_selfmenu_info')->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->current());
     }
@@ -40,13 +40,13 @@ class ClientTest extends TestCase
         $client->expects()->httpPostJson('cgi-bin/menu/addconditional', [
             'button' => ['foo' => 'bar'],
             'matchrule' => ['tag_id' => 1],
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->create(['foo' => 'bar'], ['tag_id' => 1]));
 
         // without match rule
         $client->expects()->httpPostJson('cgi-bin/menu/create', [
             'button' => ['foo' => 'bar'],
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->create(['foo' => 'bar']));
     }
 
@@ -55,11 +55,11 @@ class ClientTest extends TestCase
         $client = $this->mockApiClient(Client::class);
 
         // without menu id
-        $client->expects()->httpGet('cgi-bin/menu/delete')->andReturn('mock-result')->once();
+        $client->expects()->httpGet('cgi-bin/menu/delete')->andReturn('mock-result');
         $this->assertSame('mock-result', $client->delete());
 
         // without match rule
-        $client->expects()->httpPostJson('cgi-bin/menu/delconditional', ['menuid' => 20181723])->andReturn('mock-result')->once();
+        $client->expects()->httpPostJson('cgi-bin/menu/delconditional', ['menuid' => 20181723])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->delete(20181723));
     }
 
@@ -67,7 +67,7 @@ class ClientTest extends TestCase
     {
         $client = $this->mockApiClient(Client::class);
 
-        $client->expects()->httpPostJson('cgi-bin/menu/trymatch', ['user_id' => 'mock-user-id'])->andReturn('mock-result')->once();
+        $client->expects()->httpPostJson('cgi-bin/menu/trymatch', ['user_id' => 'mock-user-id'])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->match('mock-user-id'));
     }
 }

--- a/tests/OfficialAccount/OCR/ClientTest.php
+++ b/tests/OfficialAccount/OCR/ClientTest.php
@@ -25,13 +25,13 @@ class ClientTest extends TestCase
         $client->expects()->httpGet('cv/ocr/idcard', [
             'type' => 'photo',
             'img_url' => $path,
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->idCard($path, 'photo'));
 
         $client->expects()->httpGet('cv/ocr/idcard', [
             'type' => 'scan',
             'img_url' => $path,
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->idCard($path, 'scan'));
 
         $this->expectException(InvalidArgumentException::class);
@@ -46,7 +46,7 @@ class ClientTest extends TestCase
         $path = '/foo/bar.jpg';
         $client->expects()->httpGet('cv/ocr/bankcard', [
             'img_url' => $path,
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->bankCard($path));
     }
@@ -58,7 +58,7 @@ class ClientTest extends TestCase
         $path = '/foo/bar.jpg';
         $client->expects()->httpGet('cv/ocr/driving', [
             'img_url' => $path,
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->vehicleLicense($path));
     }

--- a/tests/OfficialAccount/POI/ClientTest.php
+++ b/tests/OfficialAccount/POI/ClientTest.php
@@ -20,7 +20,7 @@ class ClientTest extends TestCase
     {
         $client = $this->mockApiClient(Client::class);
 
-        $client->expects()->httpGet('cgi-bin/poi/getwxcategory')->andReturn('mock-result')->once();
+        $client->expects()->httpGet('cgi-bin/poi/getwxcategory')->andReturn('mock-result');
         $this->assertSame('mock-result', $client->categories());
     }
 
@@ -28,7 +28,7 @@ class ClientTest extends TestCase
     {
         $client = $this->mockApiClient(Client::class);
 
-        $client->expects()->httpPostJson('cgi-bin/poi/getpoi', ['poi_id' => 44])->andReturn('mock-result')->once();
+        $client->expects()->httpPostJson('cgi-bin/poi/getpoi', ['poi_id' => 44])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->get(44));
     }
 
@@ -36,7 +36,7 @@ class ClientTest extends TestCase
     {
         $client = $this->mockApiClient(Client::class);
 
-        $client->expects()->httpPostJson('cgi-bin/poi/delpoi', ['poi_id' => 12])->andReturn('mock-result')->once();
+        $client->expects()->httpPostJson('cgi-bin/poi/delpoi', ['poi_id' => 12])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->delete(12));
     }
 
@@ -47,13 +47,13 @@ class ClientTest extends TestCase
         $client->expects()->httpPostJson('cgi-bin/poi/getpoilist', [
             'begin' => 0,
             'limit' => 10,
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->list());
 
         $client->expects()->httpPostJson('cgi-bin/poi/getpoilist', [
             'begin' => 1,
             'limit' => 20,
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->list(1, 20));
     }
 
@@ -65,7 +65,7 @@ class ClientTest extends TestCase
             'business' => [
                 'base_info' => ['foo' => 'bar'],
             ],
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->create(['foo' => 'bar']));
     }
 
@@ -73,7 +73,7 @@ class ClientTest extends TestCase
     {
         $client = $this->mockApiClient(Client::class, ['create']);
 
-        $client->expects()->create(['foo' => 'bar'])->andReturn(['poi_id' => 'mock-id'])->once();
+        $client->expects()->create(['foo' => 'bar'])->andReturn(['poi_id' => 'mock-id']);
         $this->assertSame('mock-id', $client->createAndGetId(['foo' => 'bar']));
     }
 
@@ -88,7 +88,7 @@ class ClientTest extends TestCase
                     'poi_id' => 246,
                 ],
             ],
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->update(246, ['foo' => 'bar']));
     }
 }

--- a/tests/OfficialAccount/Semantic/ClientTest.php
+++ b/tests/OfficialAccount/Semantic/ClientTest.php
@@ -26,7 +26,7 @@ class ClientTest extends TestCase
             'category' => 'foo,bar',
             'appid' => '123456',
             'name' => 'easywechat',
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->query('keywords', 'foo,bar', ['name' => 'easywechat']));
     }

--- a/tests/OfficialAccount/ShakeAround/ClientTest.php
+++ b/tests/OfficialAccount/ShakeAround/ClientTest.php
@@ -20,7 +20,7 @@ class ClientTest extends TestCase
     {
         $client = $this->mockApiClient(Client::class);
 
-        $client->expects()->httpPostJson('shakearound/account/register', ['foo' => 'bar'])->andReturn('mock-result')->once();
+        $client->expects()->httpPostJson('shakearound/account/register', ['foo' => 'bar'])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->register(['foo' => 'bar']));
     }
@@ -29,7 +29,7 @@ class ClientTest extends TestCase
     {
         $client = $this->mockApiClient(Client::class);
 
-        $client->expects()->httpGet('shakearound/account/auditstatus')->andReturn('mock-result')->once();
+        $client->expects()->httpGet('shakearound/account/auditstatus')->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->status());
     }
@@ -38,13 +38,13 @@ class ClientTest extends TestCase
     {
         $client = $this->mockApiClient(Client::class);
 
-        $client->expects()->httpPostJson('shakearound/user/getshakeinfo', ['ticket' => 'mock-ticket'])->andReturn('mock-result')->once();
+        $client->expects()->httpPostJson('shakearound/user/getshakeinfo', ['ticket' => 'mock-ticket'])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->user('mock-ticket'));
 
-        $client->expects()->httpPostJson('shakearound/user/getshakeinfo', ['ticket' => 'mock-ticket', 'need_poi' => 1])->andReturn('mock-result')->once();
+        $client->expects()->httpPostJson('shakearound/user/getshakeinfo', ['ticket' => 'mock-ticket', 'need_poi' => 1])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->user('mock-ticket', true));
 
-        $client->expects()->httpPostJson('shakearound/user/getshakeinfo', ['ticket' => 'mock-ticket', 'need_poi' => 1])->andReturn('mock-result')->once();
+        $client->expects()->httpPostJson('shakearound/user/getshakeinfo', ['ticket' => 'mock-ticket', 'need_poi' => 1])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->userWithPoi('mock-ticket', true));
     }
 }

--- a/tests/OfficialAccount/ShakeAround/DeviceClientTest.php
+++ b/tests/OfficialAccount/ShakeAround/DeviceClientTest.php
@@ -20,7 +20,7 @@ class DeviceClientTest extends TestCase
     {
         $client = $this->mockApiClient(DeviceClient::class);
 
-        $client->expects()->httpPostJson('shakearound/device/applyid', ['foo' => 'bar'])->andReturn('mock-result')->once();
+        $client->expects()->httpPostJson('shakearound/device/applyid', ['foo' => 'bar'])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->apply(['foo' => 'bar']));
     }
@@ -29,7 +29,7 @@ class DeviceClientTest extends TestCase
     {
         $client = $this->mockApiClient(DeviceClient::class);
 
-        $client->expects()->httpPostJson('shakearound/device/applystatus', ['apply_id' => 77])->andReturn('mock-result')->once();
+        $client->expects()->httpPostJson('shakearound/device/applystatus', ['apply_id' => 77])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->status(77));
     }
@@ -43,7 +43,7 @@ class DeviceClientTest extends TestCase
                 'device_id' => 10011,
             ],
             'comment' => 'mock-comment',
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->update(['device_id' => 10011], 'mock-comment'));
     }
@@ -57,7 +57,7 @@ class DeviceClientTest extends TestCase
                 'device_id' => 10011,
             ],
             'poi_id' => 14,
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->bindPoi(['device_id' => 10011], 14));
     }
@@ -73,7 +73,7 @@ class DeviceClientTest extends TestCase
             'poi_id' => 14,
             'type' => 2,
             'poi_appid' => 'mock-app-id',
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->bindThirdPoi(['device_id' => 10011], 14, 'mock-app-id'));
     }
@@ -88,7 +88,7 @@ class DeviceClientTest extends TestCase
                 ['device_id' => 10012],
             ],
             'type' => 1,
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->listByIds([['device_id' => 10011], ['device_id' => 10012]]));
     }
@@ -101,7 +101,7 @@ class DeviceClientTest extends TestCase
             'type' => 2,
             'last_seen' => 45,
             'count' => 20,
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->list(45, 20));
     }
@@ -115,7 +115,7 @@ class DeviceClientTest extends TestCase
             'apply_id' => 56,
             'last_seen' => 45,
             'count' => 20,
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->listByApplyId(56, 45, 20));
     }
@@ -126,7 +126,7 @@ class DeviceClientTest extends TestCase
 
         $client->expects()->httpPostJson('shakearound/device/search', [
             'foo' => 'bar',
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->search(['foo' => 'bar']));
     }

--- a/tests/OfficialAccount/ShakeAround/GroupClientTest.php
+++ b/tests/OfficialAccount/ShakeAround/GroupClientTest.php
@@ -20,7 +20,7 @@ class GroupClientTest extends TestCase
     {
         $client = $this->mockApiClient(GroupClient::class);
 
-        $client->expects()->httpPostJson('shakearound/device/group/add', ['group_name' => 'foo'])->andReturn('mock-result')->once();
+        $client->expects()->httpPostJson('shakearound/device/group/add', ['group_name' => 'foo'])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->create('foo'));
     }
@@ -32,7 +32,7 @@ class GroupClientTest extends TestCase
         $client->expects()->httpPostJson('shakearound/device/group/update', [
             'group_id' => 11,
             'group_name' => 'foo',
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->update(11, 'foo'));
     }
@@ -43,7 +43,7 @@ class GroupClientTest extends TestCase
 
         $client->expects()->httpPostJson('shakearound/device/group/delete', [
             'group_id' => 11,
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->delete(11));
     }
@@ -55,7 +55,7 @@ class GroupClientTest extends TestCase
         $client->expects()->httpPostJson('shakearound/device/group/getlist', [
             'begin' => 11,
             'count' => 50,
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->list(11, 50));
     }
@@ -68,7 +68,7 @@ class GroupClientTest extends TestCase
             'group_id' => 66,
             'begin' => 11,
             'count' => 50,
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->get(66, 11, 50));
     }
@@ -80,7 +80,7 @@ class GroupClientTest extends TestCase
         $client->expects()->httpPostJson('shakearound/device/group/adddevice', [
             'group_id' => 66,
             'device_identifiers' => [['device_id' => 10011]],
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->addDevices(66, [['device_id' => 10011]]));
     }
@@ -92,7 +92,7 @@ class GroupClientTest extends TestCase
         $client->expects()->httpPostJson('shakearound/device/group/deletedevice', [
             'group_id' => 66,
             'device_identifiers' => [['device_id' => 10011]],
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->removeDevices(66, [['device_id' => 10011]]));
     }

--- a/tests/OfficialAccount/ShakeAround/MaterialClientTest.php
+++ b/tests/OfficialAccount/ShakeAround/MaterialClientTest.php
@@ -23,10 +23,10 @@ class MaterialClientTest extends TestCase
 
         $path = STUBS_ROOT.'/files/image.png';
 
-        $client->expects()->httpUpload('shakearound/material/add', ['media' => $path], [], ['type' => 'icon'])->andReturn('mock-result')->once();
+        $client->expects()->httpUpload('shakearound/material/add', ['media' => $path], [], ['type' => 'icon'])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->uploadImage($path));
 
-        $client->expects()->httpUpload('shakearound/material/add', ['media' => $path], [], ['type' => 'cover'])->andReturn('mock-result')->once();
+        $client->expects()->httpUpload('shakearound/material/add', ['media' => $path], [], ['type' => 'cover'])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->uploadImage($path, 'cover'));
 
         // invalid path

--- a/tests/OfficialAccount/ShakeAround/PageClientTest.php
+++ b/tests/OfficialAccount/ShakeAround/PageClientTest.php
@@ -20,7 +20,7 @@ class PageClientTest extends TestCase
     {
         $client = $this->mockApiClient(PageClient::class);
 
-        $client->expects()->httpPostJson('shakearound/page/add', ['foo' => 'bar'])->andReturn('mock-result')->once();
+        $client->expects()->httpPostJson('shakearound/page/add', ['foo' => 'bar'])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->create(['foo' => 'bar']));
     }
@@ -32,7 +32,7 @@ class PageClientTest extends TestCase
         $client->expects()->httpPostJson('shakearound/page/update', [
             'page_id' => 3,
             'foo' => 'bar',
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->update(3, ['foo' => 'bar']));
     }
@@ -44,7 +44,7 @@ class PageClientTest extends TestCase
         $client->expects()->httpPostJson('shakearound/page/search', [
             'type' => 1,
             'page_ids' => [1, 2, 5],
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->listByIds([1, 2, 5]));
     }
@@ -57,7 +57,7 @@ class PageClientTest extends TestCase
             'type' => 2,
             'begin' => 3,
             'count' => 20,
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->list(3, 20));
     }
@@ -68,7 +68,7 @@ class PageClientTest extends TestCase
 
         $client->expects()->httpPostJson('shakearound/page/delete', [
             'page_id' => 3,
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->delete(3));
     }

--- a/tests/OfficialAccount/ShakeAround/RelationClientTest.php
+++ b/tests/OfficialAccount/ShakeAround/RelationClientTest.php
@@ -26,7 +26,7 @@ class RelationClientTest extends TestCase
                 ['device_id' => 10012],
             ],
             'page_ids' => [1, 4],
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->bindPages([
             ['device_id' => 10011],
@@ -41,7 +41,7 @@ class RelationClientTest extends TestCase
         $client->expects()->httpPostJson('shakearound/relation/search', [
             'type' => 1,
             'device_identifier' => ['device_id' => 10011],
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->listByDeviceId(['device_id' => 10011]));
     }
@@ -55,7 +55,7 @@ class RelationClientTest extends TestCase
             'page_id' => 6,
             'begin' => 5,
             'count' => 50,
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->listByPageId(6, 5, 50));
     }

--- a/tests/OfficialAccount/ShakeAround/StatsClientTest.php
+++ b/tests/OfficialAccount/ShakeAround/StatsClientTest.php
@@ -24,7 +24,7 @@ class StatsClientTest extends TestCase
             'device_identifier' => ['device_id' => 10011],
             'begin_date' => 1438704000,
             'end_date' => 1438708000,
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->deviceSummary(['device_id' => 10011], 1438704000, 1438708000));
     }
@@ -36,7 +36,7 @@ class StatsClientTest extends TestCase
         $client->expects()->httpPostJson('shakearound/statistics/devicelist', [
             'date' => 1438704000,
             'page_index' => 5,
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->devicesSummary(1438704000, 5));
     }
@@ -49,7 +49,7 @@ class StatsClientTest extends TestCase
             'page_id' => 10011,
             'begin_date' => 1438704000,
             'end_date' => 1438708000,
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->pageSummary(10011, 1438704000, 1438708000));
     }
@@ -61,7 +61,7 @@ class StatsClientTest extends TestCase
         $client->expects()->httpPostJson('shakearound/statistics/pagelist', [
             'date' => 1438704000,
             'page_index' => 5,
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->pagesSummary(1438704000, 5));
     }

--- a/tests/OfficialAccount/Store/ClientTest.php
+++ b/tests/OfficialAccount/Store/ClientTest.php
@@ -20,7 +20,7 @@ class ClientTest extends TestCase
     {
         $client = $this->mockApiClient(Client::class);
 
-        $client->expects()->httpGet('wxa/get_merchant_category')->andReturn('mock-result')->once();
+        $client->expects()->httpGet('wxa/get_merchant_category')->andReturn('mock-result');
         $this->assertSame('mock-result', $client->categories());
     }
 
@@ -28,7 +28,7 @@ class ClientTest extends TestCase
     {
         $client = $this->mockApiClient(Client::class);
 
-        $client->expects()->httpGet('wxa/get_district')->andReturn('mock-result')->once();
+        $client->expects()->httpGet('wxa/get_district')->andReturn('mock-result');
         $this->assertSame('mock-result', $client->districts());
     }
 
@@ -39,7 +39,7 @@ class ClientTest extends TestCase
         $client->expects()->httpPostJson('wxa/search_map_poi', [
             'districtid' => 2,
             'keyword' => '北京',
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->searchFromMap(2, '北京'));
     }
 
@@ -47,7 +47,7 @@ class ClientTest extends TestCase
     {
         $client = $this->mockApiClient(Client::class);
 
-        $client->expects()->httpPostJson('wxa/get_merchant_audit_info')->andReturn('mock-result')->once();
+        $client->expects()->httpPostJson('wxa/get_merchant_audit_info')->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->getStatus());
     }
@@ -58,7 +58,7 @@ class ClientTest extends TestCase
 
         $client->expects()->httpPostJson('wxa/apply_merchant', [
             'foo' => 'bar',
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->createMerchant(['foo' => 'bar']));
     }
 
@@ -68,7 +68,7 @@ class ClientTest extends TestCase
 
         $client->expects()->httpPostJson('wxa/modify_merchant', [
             'foo' => 'bar',
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->updateMerchant(['foo' => 'bar']));
     }
 
@@ -78,7 +78,7 @@ class ClientTest extends TestCase
 
         $client->expects()->httpPostJson('wxa/create_map_poi', [
             'foo' => 'bar',
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->createFromMap(['foo' => 'bar']));
     }
 
@@ -88,7 +88,7 @@ class ClientTest extends TestCase
 
         $client->expects()->httpPostJson('wxa/add_store', [
             'foo' => 'bar',
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->create(['foo' => 'bar']));
     }
 
@@ -99,7 +99,7 @@ class ClientTest extends TestCase
         $client->expects()->httpPostJson('wxa/update_store', [
             'foo' => 'bar',
             'poi_id' => 246,
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->update(246, ['foo' => 'bar']));
     }
 
@@ -107,7 +107,7 @@ class ClientTest extends TestCase
     {
         $client = $this->mockApiClient(Client::class);
 
-        $client->expects()->httpPostJson('wxa/get_store_info', ['poi_id' => 44])->andReturn('mock-result')->once();
+        $client->expects()->httpPostJson('wxa/get_store_info', ['poi_id' => 44])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->get(44));
     }
 
@@ -118,13 +118,13 @@ class ClientTest extends TestCase
         $client->expects()->httpPostJson('wxa/get_store_list', [
             'offset' => 0,
             'limit' => 10,
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->list());
 
         $client->expects()->httpPostJson('wxa/get_store_list', [
             'offset' => 1,
             'limit' => 20,
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->list(1, 20));
     }
 
@@ -132,7 +132,7 @@ class ClientTest extends TestCase
     {
         $client = $this->mockApiClient(Client::class);
 
-        $client->expects()->httpPostJson('wxa/del_store', ['poi_id' => 12])->andReturn('mock-result')->once();
+        $client->expects()->httpPostJson('wxa/del_store', ['poi_id' => 12])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->delete(12));
     }
 }

--- a/tests/OfficialAccount/TemplateMessage/ClientTest.php
+++ b/tests/OfficialAccount/TemplateMessage/ClientTest.php
@@ -23,14 +23,14 @@ class ClientTest extends TestCase
         $client->expects()->httpPostJson('cgi-bin/template/api_set_industry', [
             'industry_id1' => 'foo',
             'industry_id2' => 'bar',
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->setIndustry('foo', 'bar'));
     }
 
     public function testGetIndustry()
     {
         $client = $this->mockApiClient(Client::class);
-        $client->expects()->httpPostJson('cgi-bin/template/get_industry')->andReturn('mock-result')->once();
+        $client->expects()->httpPostJson('cgi-bin/template/get_industry')->andReturn('mock-result');
         $this->assertSame('mock-result', $client->getIndustry());
     }
 
@@ -39,14 +39,14 @@ class ClientTest extends TestCase
         $client = $this->mockApiClient(Client::class);
         $client->expects()->httpPostJson('cgi-bin/template/api_add_template', [
             'template_id_short' => 'mock-id',
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->addTemplate('mock-id'));
     }
 
     public function testGetPrivateTemplates()
     {
         $client = $this->mockApiClient(Client::class);
-        $client->expects()->httpPostJson('cgi-bin/template/get_all_private_template')->andReturn('mock-result')->once();
+        $client->expects()->httpPostJson('cgi-bin/template/get_all_private_template')->andReturn('mock-result');
         $this->assertSame('mock-result', $client->getPrivateTemplates());
     }
 
@@ -55,7 +55,7 @@ class ClientTest extends TestCase
         $client = $this->mockApiClient(Client::class);
         $client->expects()->httpPostJson('cgi-bin/template/del_private_template', [
             'template_id' => 'mock-id',
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->deletePrivateTemplate('mock-id'));
     }
 
@@ -88,7 +88,7 @@ class ClientTest extends TestCase
             'url' => '',
             'data' => [],
             'miniprogram' => '',
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->send(['touser' => 'mock-openid', 'template_id' => 'mock-template_id']));
 
         // with miniprogram
@@ -101,7 +101,7 @@ class ClientTest extends TestCase
                 'appid' => 'id',
                 'pagepath' => 'path',
             ],
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->send(['touser' => 'mock-openid', 'template_id' => 'mock-template_id', 'miniprogram' => ['appid' => 'id', 'pagepath' => 'path']]));
     }
 
@@ -139,7 +139,7 @@ class ClientTest extends TestCase
             'url' => '',
             'data' => [],
             'miniprogram' => '',
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->sendSubscription(['touser' => 'mock-openid', 'template_id' => 'mock-template_id']));
 
         $client->expects()->httpPostJson('cgi-bin/message/template/subscribe', [
@@ -152,7 +152,7 @@ class ClientTest extends TestCase
                     'content' => ['value' => 'VALUE'],
                 ],
             'miniprogram' => '',
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->sendSubscription([
             'touser' => 'foo',

--- a/tests/OfficialAccount/User/TagClientTest.php
+++ b/tests/OfficialAccount/User/TagClientTest.php
@@ -22,7 +22,7 @@ class TagClientTest extends TestCase
 
         $client->expects()->httpPostJson('cgi-bin/tags/create', [
             'tag' => ['name' => '粉丝'],
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->create('粉丝'));
     }
@@ -31,7 +31,7 @@ class TagClientTest extends TestCase
     {
         $client = $this->mockApiClient(TagClient::class);
 
-        $client->expects()->httpGet('cgi-bin/tags/get')->andReturn('mock-result')->once();
+        $client->expects()->httpGet('cgi-bin/tags/get')->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->list());
     }
@@ -45,7 +45,7 @@ class TagClientTest extends TestCase
                 'id' => 12,
                 'name' => '粉丝',
             ],
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->update(12, '粉丝'));
     }
@@ -58,7 +58,7 @@ class TagClientTest extends TestCase
             'tag' => [
                 'id' => 12,
             ],
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->delete(12));
     }
@@ -69,7 +69,7 @@ class TagClientTest extends TestCase
 
         $client->expects()->httpPostJson('cgi-bin/tags/getidlist', [
             'openid' => 'mock-openid',
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->userTags('mock-openid'));
     }
@@ -81,13 +81,13 @@ class TagClientTest extends TestCase
         $client->expects()->httpPostJson('cgi-bin/user/tag/get', [
             'tagid' => 45,
             'next_openid' => '',
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->usersOfTag(45));
 
         $client->expects()->httpPostJson('cgi-bin/user/tag/get', [
             'tagid' => 45,
             'next_openid' => 'mock-openid',
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->usersOfTag(45, 'mock-openid'));
     }
 
@@ -98,7 +98,7 @@ class TagClientTest extends TestCase
         $client->expects()->httpPostJson('cgi-bin/tags/members/batchtagging', [
             'openid_list' => ['openid1', 'openid2'],
             'tagid' => 45,
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->tagUsers(['openid1', 'openid2'], 45));
     }
 
@@ -109,7 +109,7 @@ class TagClientTest extends TestCase
         $client->expects()->httpPostJson('cgi-bin/tags/members/batchuntagging', [
             'openid_list' => ['openid1', 'openid2'],
             'tagid' => 45,
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->untagUsers(['openid1', 'openid2'], 45));
     }
 }

--- a/tests/OfficialAccount/User/UserClientTest.php
+++ b/tests/OfficialAccount/User/UserClientTest.php
@@ -23,13 +23,13 @@ class UserClientTest extends TestCase
         $client->expects()->httpGet('cgi-bin/user/info', [
             'openid' => 'mock-openid',
             'lang' => 'zh_CN',
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->get('mock-openid'));
 
         $client->expects()->httpGet('cgi-bin/user/info', [
             'openid' => 'mock-openid',
             'lang' => 'en',
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->get('mock-openid', 'en'));
     }
 
@@ -48,7 +48,7 @@ class UserClientTest extends TestCase
                     'lang' => 'zh_CN',
                 ],
             ],
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->select(['mock-openid1', 'mock-openid2']));
 
         $client->expects()->httpPostJson('cgi-bin/user/info/batchget', [
@@ -62,7 +62,7 @@ class UserClientTest extends TestCase
                     'lang' => 'en',
                 ],
             ],
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->select(['mock-openid1', 'mock-openid2'], 'en'));
     }
 
@@ -70,10 +70,10 @@ class UserClientTest extends TestCase
     {
         $client = $this->mockApiClient(UserClient::class);
 
-        $client->expects()->httpGet('cgi-bin/user/get', ['next_openid' => null])->andReturn('mock-result')->once();
+        $client->expects()->httpGet('cgi-bin/user/get', ['next_openid' => null])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->list());
 
-        $client->expects()->httpGet('cgi-bin/user/get', ['next_openid' => 'mock-openid'])->andReturn('mock-result')->once();
+        $client->expects()->httpGet('cgi-bin/user/get', ['next_openid' => 'mock-openid'])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->list('mock-openid'));
     }
 
@@ -84,7 +84,7 @@ class UserClientTest extends TestCase
         $client->expects()->httpPostJson('cgi-bin/user/info/updateremark', [
             'openid' => 'mock-openid',
             'remark' => 'mock-remark',
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->remark('mock-openid', 'mock-remark'));
     }
 
@@ -92,10 +92,10 @@ class UserClientTest extends TestCase
     {
         $client = $this->mockApiClient(UserClient::class);
 
-        $client->expects()->httpPostJson('cgi-bin/tags/members/getblacklist', ['begin_openid' => null])->andReturn('mock-result')->once();
+        $client->expects()->httpPostJson('cgi-bin/tags/members/getblacklist', ['begin_openid' => null])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->blacklist());
 
-        $client->expects()->httpPostJson('cgi-bin/tags/members/getblacklist', ['begin_openid' => 'mock-openid'])->andReturn('mock-result')->once();
+        $client->expects()->httpPostJson('cgi-bin/tags/members/getblacklist', ['begin_openid' => 'mock-openid'])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->blacklist('mock-openid'));
     }
 
@@ -105,12 +105,12 @@ class UserClientTest extends TestCase
 
         $client->expects()->httpPostJson('cgi-bin/tags/members/batchblacklist', [
             'openid_list' => ['mock-openid1'],
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->block('mock-openid1'));
 
         $client->expects()->httpPostJson('cgi-bin/tags/members/batchblacklist', [
             'openid_list' => ['mock-openid1', 'mock-openid2'],
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->block(['mock-openid1', 'mock-openid2']));
     }
 
@@ -120,12 +120,12 @@ class UserClientTest extends TestCase
 
         $client->expects()->httpPostJson('cgi-bin/tags/members/batchunblacklist', [
             'openid_list' => ['mock-openid1'],
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->unblock('mock-openid1'));
 
         $client->expects()->httpPostJson('cgi-bin/tags/members/batchunblacklist', [
             'openid_list' => ['mock-openid1', 'mock-openid2'],
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->unblock(['mock-openid1', 'mock-openid2']));
     }
 
@@ -136,7 +136,7 @@ class UserClientTest extends TestCase
         $client->expects()->httpPostJson('cgi-bin/changeopenid', [
             'from_appid' => 'old-appid',
             'openid_list' => ['openid1', 'openid2'],
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->changeOpenid('old-appid', ['openid1', 'openid2']));
     }
 }

--- a/tests/OpenPlatform/ApplicationTest.php
+++ b/tests/OpenPlatform/ApplicationTest.php
@@ -33,7 +33,7 @@ class ApplicationTest extends TestCase
         $app = \Mockery::mock(Application::class.'[createPreAuthorizationCode]', ['app_id' => 'component-app-id'], function ($mock) {
             $mock->expects()->createPreAuthorizationCode()->andReturn([
                 'pre_auth_code' => 'auth-code@123456',
-            ])->once();
+            ]);
         });
 
         $this->assertSame(
@@ -52,7 +52,7 @@ class ApplicationTest extends TestCase
         $app = \Mockery::mock(Application::class.'[createPreAuthorizationCode]', ['app_id' => 'component-app-id'], function ($mock) {
             $mock->expects()->createPreAuthorizationCode()->andReturn([
                 'pre_auth_code' => 'auth-code@123456',
-            ])->once();
+            ]);
         });
 
         $this->assertSame(

--- a/tests/OpenPlatform/Auth/AccessTokenTest.php
+++ b/tests/OpenPlatform/Auth/AccessTokenTest.php
@@ -21,7 +21,7 @@ class AccessTokenTest extends TestCase
     public function testGetCredentials()
     {
         $verifyTicket = \Mockery::mock(VerifyTicket::class, function ($mock) {
-            $mock->expects()->getTicket()->andReturn('ticket@123456')->once();
+            $mock->expects()->getTicket()->andReturn('ticket@123456');
         });
 
         $app = new ServiceContainer([

--- a/tests/OpenPlatform/Auth/VerifyTicketTest.php
+++ b/tests/OpenPlatform/Auth/VerifyTicketTest.php
@@ -24,7 +24,7 @@ class VerifyTicketTest extends TestCase
         $client = \Mockery::mock(VerifyTicket::class.'[getCache]', [new Application(['app_id' => 'app-id'])], function ($mock) {
             $cache = \Mockery::mock(CacheInterface::class, function ($mock) {
                 $key = 'easywechat.open_platform.verify_ticket.app-id';
-                $mock->expects()->set($key, 'ticket@654321', 3600)->once()->andReturn(true);
+                $mock->expects()->set($key, 'ticket@654321', 3600)->andReturn(true);
                 $mock->expects()->has($key)->andReturn(true);
             });
             $mock->allows()->getCache()->andReturn($cache);
@@ -37,7 +37,7 @@ class VerifyTicketTest extends TestCase
         $client = \Mockery::mock(VerifyTicket::class.'[getCache]', [new Application(['app_id' => 'app-id'])], function ($mock) {
             $cache = \Mockery::mock(CacheInterface::class, function ($mock) {
                 $key = 'easywechat.open_platform.verify_ticket.app-id';
-                $mock->expects()->set($key, 'ticket@654321', 3600)->once()->andReturn(false);
+                $mock->expects()->set($key, 'ticket@654321', 3600)->andReturn(false);
                 $mock->expects()->has($key)->andReturn(false);
             });
             $mock->allows()->getCache()->andReturn($cache);
@@ -50,7 +50,7 @@ class VerifyTicketTest extends TestCase
         $client = \Mockery::mock(VerifyTicket::class.'[getCache]', [new Application(['app_id' => 'app-id'])], function ($mock) {
             $cache = \Mockery::mock(CacheInterface::class, function ($mock) {
                 $key = 'easywechat.open_platform.verify_ticket.app-id';
-                $mock->expects()->get($key)->andReturn('ticket@123456')->once();
+                $mock->expects()->get($key)->andReturn('ticket@123456');
             });
             $mock->allows()->getCache()->andReturn($cache);
         });
@@ -63,7 +63,7 @@ class VerifyTicketTest extends TestCase
         $client = \Mockery::mock(VerifyTicket::class.'[getCache]', [new Application(['app_id' => 'app-id'])], function ($mock) {
             $cache = \Mockery::mock(CacheInterface::class, function ($mock) {
                 $key = 'easywechat.open_platform.verify_ticket.app-id';
-                $mock->expects()->get($key)->andReturn(null)->once();
+                $mock->expects()->get($key)->andReturn(null);
             });
             $mock->allows()->getCache()->andReturn($cache);
         });

--- a/tests/OpenPlatform/Authorizer/Aggregate/Account/ClientTest.php
+++ b/tests/OpenPlatform/Authorizer/Aggregate/Account/ClientTest.php
@@ -21,7 +21,7 @@ class ClientTest extends TestCase
     {
         $client = $this->mockApiClient(Client::class, [], new ServiceContainer(['app_id' => 'app-id']));
 
-        $client->expects()->httpPostJson('cgi-bin/open/create', ['appid' => 'app-id'])->andReturn('mock-result')->once();
+        $client->expects()->httpPostJson('cgi-bin/open/create', ['appid' => 'app-id'])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->create());
     }
 
@@ -29,7 +29,7 @@ class ClientTest extends TestCase
     {
         $client = $this->mockApiClient(Client::class, [], new ServiceContainer(['app_id' => 'app-id']));
 
-        $client->expects()->httpPostJson('cgi-bin/open/bind', ['appid' => 'app-id', 'open_appid' => 'open-app-id'])->andReturn('mock-result')->once();
+        $client->expects()->httpPostJson('cgi-bin/open/bind', ['appid' => 'app-id', 'open_appid' => 'open-app-id'])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->bindTo('open-app-id'));
     }
 
@@ -37,7 +37,7 @@ class ClientTest extends TestCase
     {
         $client = $this->mockApiClient(Client::class, [], new ServiceContainer(['app_id' => 'app-id']));
 
-        $client->expects()->httpPostJson('cgi-bin/open/unbind', ['appid' => 'app-id', 'open_appid' => 'open-app-id'])->andReturn('mock-result')->once();
+        $client->expects()->httpPostJson('cgi-bin/open/unbind', ['appid' => 'app-id', 'open_appid' => 'open-app-id'])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->unbindFrom('open-app-id'));
     }
 
@@ -45,7 +45,7 @@ class ClientTest extends TestCase
     {
         $client = $this->mockApiClient(Client::class, [], new ServiceContainer(['app_id' => 'app-id']));
 
-        $client->expects()->httpPostJson('cgi-bin/open/get', ['appid' => 'app-id'])->andReturn('mock-result')->once();
+        $client->expects()->httpPostJson('cgi-bin/open/get', ['appid' => 'app-id'])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->getBinding());
     }
 }

--- a/tests/OpenPlatform/Authorizer/MiniProgram/Account/ClientTest.php
+++ b/tests/OpenPlatform/Authorizer/MiniProgram/Account/ClientTest.php
@@ -27,7 +27,7 @@ class ClientTest extends TestCase
     {
         $this->client->expects()
             ->httpPostJson('cgi-bin/account/getaccountbasicinfo')
-            ->andReturn('mock-result')->once();
+            ->andReturn('mock-result');
         $this->assertSame('mock-result', $this->client->getBasicInfo());
     }
 
@@ -37,7 +37,7 @@ class ClientTest extends TestCase
             ->httpPostJson('cgi-bin/account/modifyheadimage', [
                 'head_img_media_id' => 'media-id',
                 'x1' => 0, 'y1' => 0, 'x2' => 1, 'y2' => 1,
-            ])->andReturn('mock-result')->once();
+            ])->andReturn('mock-result');
         $this->assertSame(
             'mock-result', $this->client->updateAvatar('media-id'));
     }
@@ -47,7 +47,7 @@ class ClientTest extends TestCase
         $this->client->expects()
             ->httpPostJson('cgi-bin/account/modifysignature', [
                 'signature' => 'signature',
-            ])->andReturn('mock-result')->once();
+            ])->andReturn('mock-result');
         $this->assertSame(
             'mock-result', $this->client->updateSignature('signature'));
     }

--- a/tests/OpenPlatform/Authorizer/MiniProgram/Code/ClientTest.php
+++ b/tests/OpenPlatform/Authorizer/MiniProgram/Code/ClientTest.php
@@ -26,7 +26,7 @@ class ClientTest extends TestCase
             'ext_json' => '{"foo":"bar"}',
             'user_version' => 'v1.0',
             'user_desc' => 'First commit.',
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->commit(123, '{"foo":"bar"}', 'v1.0', 'First commit.'));
     }
 

--- a/tests/OpenPlatform/Authorizer/MiniProgram/Domain/ClientTest.php
+++ b/tests/OpenPlatform/Authorizer/MiniProgram/Domain/ClientTest.php
@@ -21,7 +21,7 @@ class ClientTest extends TestCase
     {
         $client = $this->mockApiClient(Client::class, [], new ServiceContainer(['app_id' => 'app-id']));
 
-        $client->expects()->httpPostJson('wxa/modify_domain', ['foo' => 'bar'])->andReturn('mock-result')->once();
+        $client->expects()->httpPostJson('wxa/modify_domain', ['foo' => 'bar'])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->modify(['foo' => 'bar']));
     }
 
@@ -29,7 +29,7 @@ class ClientTest extends TestCase
     {
         $client = $this->mockApiClient(Client::class, [], new ServiceContainer(['app_id' => 'app-id']));
 
-        $client->expects()->httpPostJson('wxa/setwebviewdomain', ['webviewdomain' => ['bar'], 'action' => 'add'])->andReturn('mock-result')->once();
+        $client->expects()->httpPostJson('wxa/setwebviewdomain', ['webviewdomain' => ['bar'], 'action' => 'add'])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->setWebviewDomain(['bar']));
     }
 }

--- a/tests/OpenPlatform/Authorizer/MiniProgram/Setting/ClientTest.php
+++ b/tests/OpenPlatform/Authorizer/MiniProgram/Setting/ClientTest.php
@@ -27,7 +27,7 @@ class ClientTest extends TestCase
     {
         $this->client->expects()
             ->httpPostJson('cgi-bin/wxopen/getallcategories')
-            ->andReturn('mock-result')->once();
+            ->andReturn('mock-result');
         $this->assertSame(
             'mock-result', $this->client->getAllCategories());
     }
@@ -42,7 +42,7 @@ class ClientTest extends TestCase
                         ['key' => 'name', 'value' => 'media_id'],
                     ],
                 ]],
-            ])->andReturn('mock-result')->once();
+            ])->andReturn('mock-result');
         $this->assertSame('mock-result', $this->client->addCategories([[
             'first' => 1, 'second' => 2,
             'certicates' => [
@@ -56,7 +56,7 @@ class ClientTest extends TestCase
         $this->client->expects()
             ->httpPostJson('cgi-bin/wxopen/deletecategory', [
                 'first' => 1, 'second' => 2,
-            ])->andReturn('mock-result')->once();
+            ])->andReturn('mock-result');
         $this->assertSame('mock-result', $this->client->deleteCategories(1, 2));
     }
 
@@ -64,7 +64,7 @@ class ClientTest extends TestCase
     {
         $this->client->expects()
             ->httpPostJson('cgi-bin/wxopen/getcategory')
-            ->andReturn('mock-result')->once();
+            ->andReturn('mock-result');
         $this->assertSame('mock-result', $this->client->getCategories());
     }
 
@@ -75,7 +75,7 @@ class ClientTest extends TestCase
                 'first' => 1, 'second' => 2, 'categories' => [
                     ['key' => 'name', 'value' => 'media_id'],
                 ],
-            ])->andReturn('mock-result')->once();
+            ])->andReturn('mock-result');
         $this->assertSame('mock-result', $this->client->updateCategory([
             'first' => 1, 'second' => 2, 'categories' => [
                 ['key' => 'name', 'value' => 'media_id'],
@@ -91,7 +91,7 @@ class ClientTest extends TestCase
             'license' => 'media_id',
             'naming_other_stuff_1' => 'stuff_01',
             'naming_other_stuff_2' => 'stuff_02',
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
         $this->assertSame('mock-result', $this->client->setNickname(
             'name', 'card_no', 'media_id', ['stuff_01', 'stuff_02']));
     }
@@ -100,7 +100,7 @@ class ClientTest extends TestCase
     {
         $this->client->expects()->httpPostJson('wxa/api_wxa_querynickname', [
             'audit_id' => 'audit-id',
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
         $this->assertSame(
             'mock-result', $this->client->getNicknameAuditStatus('audit-id'));
     }
@@ -109,14 +109,14 @@ class ClientTest extends TestCase
     {
         $this->client->expects()->httpPostJson('cgi-bin/wxverify/checkwxverifynickname', [
             'nick_name' => 'name',
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
         $this->assertSame(
             'mock-result', $this->client->isAvailableNickname('name'));
     }
 
     public function testGetSearchStatus()
     {
-        $this->client->expects()->httpGet('wxa/getwxasearchstatus')->andReturn('mock-result')->once();
+        $this->client->expects()->httpGet('wxa/getwxasearchstatus')->andReturn('mock-result');
         $this->assertSame('mock-result', $this->client->getSearchStatus());
     }
 
@@ -124,7 +124,7 @@ class ClientTest extends TestCase
     {
         $this->client->expects()->httpPostJson('wxa/changewxasearchstatus', [
             'status' => 0,
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
         $this->assertSame('mock-result', $this->client->setSearchable());
     }
 
@@ -132,13 +132,13 @@ class ClientTest extends TestCase
     {
         $this->client->expects()->httpPostJson('wxa/changewxasearchstatus', [
             'status' => 1,
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
         $this->assertSame('mock-result', $this->client->setUnsearchable());
     }
 
     public function testGetDisplayedOfficialAccount()
     {
-        $this->client->expects()->httpGet('wxa/getshowwxaitem')->andReturn('mock-result')->once();
+        $this->client->expects()->httpGet('wxa/getshowwxaitem')->andReturn('mock-result');
         $this->assertSame('mock-result', $this->client->getDisplayedOfficialAccount());
     }
 
@@ -147,7 +147,7 @@ class ClientTest extends TestCase
         $this->client->expects()->httpPostJson('wxa/updateshowwxaitem', [
             'appid' => 'app-id',
             'wxa_subscribe_biz_flag' => 1,
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
         $this->assertSame('mock-result', $this->client->setDisplayedOfficialAccount('app-id'));
     }
 
@@ -156,7 +156,7 @@ class ClientTest extends TestCase
         $this->client->expects()->httpPostJson('wxa/updateshowwxaitem', [
             'appid' => null,
             'wxa_subscribe_biz_flag' => 0,
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
         $this->assertSame('mock-result', $this->client->setDisplayedOfficialAccount(false));
     }
 
@@ -165,7 +165,7 @@ class ClientTest extends TestCase
         $this->client->expects()->httpGet('wxa/getwxamplinkforshow', [
             'page' => 1,
             'num' => 10,
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
         $this->assertSame('mock-result', $this->client->getDisplayableOfficialAccounts(1, 10));
     }
 }

--- a/tests/OpenPlatform/Authorizer/MiniProgram/Tester/ClientTest.php
+++ b/tests/OpenPlatform/Authorizer/MiniProgram/Tester/ClientTest.php
@@ -20,21 +20,21 @@ class ClientTest extends TestCase
     public function testBind()
     {
         $client = $this->mockApiClient(Client::class, [], new ServiceContainer(['app_id' => 'app-id']));
-        $client->expects()->httpPostJson('wxa/bind_tester', ['wechatid' => 'bar'])->andReturn('mock-result')->once();
+        $client->expects()->httpPostJson('wxa/bind_tester', ['wechatid' => 'bar'])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->bind('bar'));
     }
 
     public function testUnbind()
     {
         $client = $this->mockApiClient(Client::class, [], new ServiceContainer(['app_id' => 'app-id']));
-        $client->expects()->httpPostJson('wxa/unbind_tester', ['wechatid' => 'bar'])->andReturn('mock-result')->once();
+        $client->expects()->httpPostJson('wxa/unbind_tester', ['wechatid' => 'bar'])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->unbind('bar'));
     }
 
     public function testList()
     {
         $client = $this->mockApiClient(Client::class, [], new ServiceContainer(['app_id' => 'app-id']));
-        $client->expects()->httpPostJson('wxa/memberauth', ['action' => 'get_experiencer'])->andReturn('mock-result')->once();
+        $client->expects()->httpPostJson('wxa/memberauth', ['action' => 'get_experiencer'])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->list('bar'));
     }
 }

--- a/tests/OpenPlatform/Authorizer/OfficialAccount/Account/ClientTest.php
+++ b/tests/OpenPlatform/Authorizer/OfficialAccount/Account/ClientTest.php
@@ -36,7 +36,7 @@ class ClientTest extends TestCase
         $client = \Mockery::mock(Client::class.'[httpPostJson]', [new Application(['app_id' => 'app-id']), $app]);
         $client->expects()->httpPostJson('cgi-bin/account/fastregister', [
             'ticket' => 'ticket',
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->register('ticket'));
     }
 }

--- a/tests/OpenPlatform/Authorizer/OfficialAccount/MiniProgram/ClientTest.php
+++ b/tests/OpenPlatform/Authorizer/OfficialAccount/MiniProgram/ClientTest.php
@@ -20,7 +20,7 @@ class ClientTest extends TestCase
     public function testList()
     {
         $client = $this->mockApiClient(Client::class, [], new ServiceContainer(['app_id' => 'app-id']));
-        $client->expects()->httpPostJson('cgi-bin/wxopen/wxamplinkget')->andReturn('mock-result')->once();
+        $client->expects()->httpPostJson('cgi-bin/wxopen/wxamplinkget')->andReturn('mock-result');
         $this->assertSame('mock-result', $client->list());
     }
 
@@ -31,7 +31,7 @@ class ClientTest extends TestCase
             'appid' => 'wxa',
             'notify_users' => false,
             'show_profile' => true,
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->link('wxa', false, true));
     }
 
@@ -40,7 +40,7 @@ class ClientTest extends TestCase
         $client = $this->mockApiClient(Client::class, [], new ServiceContainer(['app_id' => 'app-id']));
         $client->expects()->httpPostJson('cgi-bin/wxopen/wxampunlink', [
             'appid' => 'wxa',
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->unlink('wxa'));
     }
 }

--- a/tests/OpenPlatform/Base/ClientTest.php
+++ b/tests/OpenPlatform/Base/ClientTest.php
@@ -25,7 +25,7 @@ class ClientTest extends TestCase
         $client->expects()->httpPostJson('cgi-bin/component/api_query_auth', [
             'component_appid' => '123456',
             'authorization_code' => 'auth-code',
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->handleAuthorize('auth-code'));
     }
@@ -37,7 +37,7 @@ class ClientTest extends TestCase
         $client->expects()->httpPostJson('cgi-bin/component/api_query_auth', [
             'component_appid' => '123456',
             'authorization_code' => 'auth-code-from-request',
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->handleAuthorize());
     }
@@ -49,7 +49,7 @@ class ClientTest extends TestCase
         $client->expects()->httpPostJson('cgi-bin/component/api_get_authorizer_info', [
             'component_appid' => '123456',
             'authorizer_appid' => '654321',
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->getAuthorizer('654321'));
     }
@@ -62,7 +62,7 @@ class ClientTest extends TestCase
             'component_appid' => '123456',
             'authorizer_appid' => '654321',
             'option_name' => 'foobar',
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->getAuthorizerOption('654321', 'foobar'));
     }
@@ -76,7 +76,7 @@ class ClientTest extends TestCase
             'authorizer_appid' => '654321',
             'option_name' => 'foobar',
             'option_value' => 'baz',
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->setAuthorizerOption('654321', 'foobar', 'baz'));
     }
@@ -89,7 +89,7 @@ class ClientTest extends TestCase
             'component_appid' => '123456',
             'offset' => '0',
             'count' => '500',
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->getAuthorizers());
 
@@ -97,7 +97,7 @@ class ClientTest extends TestCase
             'component_appid' => '123456',
             'offset' => '20',
             'count' => '100',
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->getAuthorizers(20, 100));
     }
@@ -109,7 +109,7 @@ class ClientTest extends TestCase
         $client->expects()
             ->httpPostJson('cgi-bin/component/api_create_preauthcode', ['component_appid' => '123456'])
             ->andReturn('mock-result')
-            ->once();
+            ;
 
         $result = $client->createPreAuthorizationCode();
 
@@ -126,7 +126,7 @@ class ClientTest extends TestCase
         $client->expects()
             ->httpPostJson('cgi-bin/component/clear_quota', ['component_appid' => '123456'])
             ->andReturn('mock-result')
-            ->once();
+            ;
 
         $result = $client->clearQuota();
 

--- a/tests/OpenPlatform/CodeTemplate/ClientTest.php
+++ b/tests/OpenPlatform/CodeTemplate/ClientTest.php
@@ -20,7 +20,7 @@ class ClientTest extends TestCase
     {
         $client = $this->mockApiClient(Client::class, []);
 
-        $client->expects()->httpGet('wxa/gettemplatedraftlist')->andReturn('mock-result')->once();
+        $client->expects()->httpGet('wxa/gettemplatedraftlist')->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->getDrafts());
     }
@@ -29,7 +29,7 @@ class ClientTest extends TestCase
     {
         $client = $this->mockApiClient(Client::class, []);
 
-        $client->expects()->httpPostJson('wxa/addtotemplate', ['draft_id' => 123])->andReturn('mock-result')->once();
+        $client->expects()->httpPostJson('wxa/addtotemplate', ['draft_id' => 123])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->createFromDraft(123));
     }
@@ -38,7 +38,7 @@ class ClientTest extends TestCase
     {
         $client = $this->mockApiClient(Client::class, []);
 
-        $client->expects()->httpGet('wxa/gettemplatelist')->andReturn('mock-result')->once();
+        $client->expects()->httpGet('wxa/gettemplatelist')->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->list());
     }
@@ -47,7 +47,7 @@ class ClientTest extends TestCase
     {
         $client = $this->mockApiClient(Client::class, []);
 
-        $client->expects()->httpPostJson('wxa/deletetemplate', ['template_id' => 234])->andReturn('mock-result')->once();
+        $client->expects()->httpPostJson('wxa/deletetemplate', ['template_id' => 234])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->delete(234));
     }

--- a/tests/OpenPlatform/Component/ClientTest.php
+++ b/tests/OpenPlatform/Component/ClientTest.php
@@ -29,7 +29,7 @@ class ClientTest extends TestCase
             'component_phone' => '111',
         ];
 
-        $client->expects()->httpPostJson('cgi-bin/component/fastregisterweapp', $params, ['action' => 'create'])->andReturn('mock-result')->once();
+        $client->expects()->httpPostJson('cgi-bin/component/fastregisterweapp', $params, ['action' => 'create'])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->registerMiniProgram($params));
     }
@@ -44,7 +44,7 @@ class ClientTest extends TestCase
             'legal_persona_name' => 'aaa111',
         ];
 
-        $client->expects()->httpPostJson('cgi-bin/component/fastregisterweapp', $params, ['action' => 'search'])->andReturn('mock-result')->once();
+        $client->expects()->httpPostJson('cgi-bin/component/fastregisterweapp', $params, ['action' => 'search'])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->getRegistrationStatus('aaa', 'aaa111', 'aaa111'));
     }

--- a/tests/OpenPlatform/Server/Handlers/VerifyTicketRefreshedTest.php
+++ b/tests/OpenPlatform/Server/Handlers/VerifyTicketRefreshedTest.php
@@ -22,7 +22,7 @@ class VerifyTicketRefreshedTest extends TestCase
     {
         $app = new Application();
         $app['verify_ticket'] = \Mockery::mock(VerifyTicket::class, function ($mock) {
-            $mock->expects()->setTicket('ticket')->once();
+            $mock->expects()->setTicket('ticket');
         });
         $handler = new VerifyTicketRefreshed($app);
 

--- a/tests/OpenWork/SuiteAuth/AccessTokenTest.php
+++ b/tests/OpenWork/SuiteAuth/AccessTokenTest.php
@@ -21,7 +21,7 @@ class AccessTokenTest extends TestCase
     public function testGetCredentials()
     {
         $suitTicket = \Mockery::mock(SuiteTicket::class, function ($mock) {
-            $mock->expects()->getTicket()->andReturn('mock-suit-ticket')->once();
+            $mock->expects()->getTicket()->andReturn('mock-suit-ticket');
         });
 
         $app = new ServiceContainer([

--- a/tests/OpenWork/SuiteAuth/SuiteTicketTest.php
+++ b/tests/OpenWork/SuiteAuth/SuiteTicketTest.php
@@ -24,7 +24,7 @@ class SuiteTicketTest extends TestCase
         $client = \Mockery::mock(SuiteTicket::class.'[getCache]', [new Application(['suite_id' => 'mock-suite-id'])], function ($mock) {
             $cache = \Mockery::mock(CacheInterface::class, function ($mock) {
                 $key = 'easywechat.open_work.suite_ticket.mock-suite-id';
-                $mock->expects()->set($key, 'mock-suit-ticket@666', 1800)->once()->andReturn(true);
+                $mock->expects()->set($key, 'mock-suit-ticket@666', 1800)->andReturn(true);
                 $mock->expects()->has($key)->andReturn(true);
             });
             $mock->allows()->getCache()->andReturn($cache);
@@ -40,7 +40,7 @@ class SuiteTicketTest extends TestCase
         $client = \Mockery::mock(SuiteTicket::class.'[getCache]', [new Application(['suite_id' => 'mock-suite-id'])], function ($mock) {
             $cache = \Mockery::mock(CacheInterface::class, function ($mock) {
                 $key = 'easywechat.open_work.suite_ticket.mock-suite-id';
-                $mock->expects()->set($key, 'mock-suit-ticket@666', 1800)->once();
+                $mock->expects()->set($key, 'mock-suit-ticket@666', 1800);
                 $mock->expects()->has($key)->andReturn(false);
             });
             $mock->allows()->getCache()->andReturn($cache);
@@ -52,7 +52,7 @@ class SuiteTicketTest extends TestCase
     {
         $client = \Mockery::mock(SuiteTicket::class.'[getCache]', [new Application(['suite_id' => 'mock-suite-id'])], function ($mock) {
             $cache = \Mockery::mock(CacheInterface::class, function ($mock) {
-                $mock->expects()->get('easywechat.open_work.suite_ticket.mock-suite-id')->once()->andReturn('mock-suit-ticket@666');
+                $mock->expects()->get('easywechat.open_work.suite_ticket.mock-suite-id')->andReturn('mock-suit-ticket@666');
             });
             $mock->allows()->getCache()->andReturn($cache);
         });
@@ -64,7 +64,7 @@ class SuiteTicketTest extends TestCase
     {
         $client = \Mockery::mock(SuiteTicket::class.'[getCache]', [new Application(['suite_id' => 'mock-suite-id'])], function ($mock) {
             $cache = \Mockery::mock(CacheInterface::class, function ($mock) {
-                $mock->expects()->get('easywechat.open_work.suite_ticket.mock-suite-id')->once()->andReturn(null);
+                $mock->expects()->get('easywechat.open_work.suite_ticket.mock-suite-id')->andReturn(null);
             });
             $mock->allows()->getCache()->andReturn($cache);
         });

--- a/tests/Payment/Bill/ClientTest.php
+++ b/tests/Payment/Bill/ClientTest.php
@@ -33,14 +33,14 @@ class ClientTest extends TestCase
             'bill_type' => 'ALL',
         ];
         // stream response
-        $client->expects()->requestRaw('pay/downloadbill', $params)->andReturn(new Response(200, ['text/plain'], 'mock-content'))->once();
+        $client->expects()->requestRaw('pay/downloadbill', $params)->andReturn(new Response(200, ['text/plain'], 'mock-content'));
         $this->assertInstanceOf(StreamResponse::class, $client->get('20171010'));
 
         $response = new Response(200, ['Content-Type' => ['text/plain']], '<xml><return_code><![CDATA[FAIL]]></return_code>
 <return_msg><![CDATA[invalid bill_date]]></return_msg>
 <error_code><![CDATA[20001]]></error_code>
 </xml>');
-        $client->expects()->requestRaw('pay/downloadbill', $params)->andReturn($response)->once();
+        $client->expects()->requestRaw('pay/downloadbill', $params)->andReturn($response);
 
         $result = $client->get('20171010');
         $this->assertArraySubset([

--- a/tests/Payment/Kernel/BaseClientTest.php
+++ b/tests/Payment/Kernel/BaseClientTest.php
@@ -23,7 +23,7 @@ class BaseClientTest extends TestCase
     {
         $app = new Application(['key' => '88888888888888888888888888888888']);
 
-        $client = $this->mockApiClient(BaseClient::class, ['performRequest', 'castResponseToType'], $app)->shouldDeferMissing();
+        $client = $this->mockApiClient(BaseClient::class, ['performRequest', 'castResponseToType'], $app)->makePartial();
 
         $api = 'http://easywechat.org';
         $params = ['foo' => 'bar'];
@@ -106,7 +106,7 @@ class BaseClientTest extends TestCase
             'key' => '88888888888888888888888888888888',
         ]);
 
-        $client = $this->mockApiClient(BaseClient::class, ['performRequest'], $app)->shouldDeferMissing();
+        $client = $this->mockApiClient(BaseClient::class, ['performRequest'], $app)->makePartial();
 
         $api = 'http://easywechat.org';
         $params = [

--- a/tests/Work/Agent/ClientTest.php
+++ b/tests/Work/Agent/ClientTest.php
@@ -20,7 +20,7 @@ class ClientTest extends TestCase
     public function testGet()
     {
         $client = $this->mockApiClient(Client::class, [], new ServiceContainer(['agent_id' => 203874]));
-        $client->expects()->httpGet('cgi-bin/agent/get', ['agentid' => 203874])->andReturn('mock-result')->once();
+        $client->expects()->httpGet('cgi-bin/agent/get', ['agentid' => 203874])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->get(203874));
     }
 
@@ -30,14 +30,14 @@ class ClientTest extends TestCase
         $client->expects()->httpPostJson('cgi-bin/agent/set', [
             'agentid' => 203874,
             'foo' => 'bar',
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->set(203874, ['foo' => 'bar']));
     }
 
     public function testList()
     {
         $client = $this->mockApiClient(Client::class);
-        $client->expects()->httpGet('cgi-bin/agent/list')->andReturn('mock-result')->once();
+        $client->expects()->httpGet('cgi-bin/agent/list')->andReturn('mock-result');
         $this->assertSame('mock-result', $client->list());
     }
 }

--- a/tests/Work/Base/ClientTest.php
+++ b/tests/Work/Base/ClientTest.php
@@ -20,7 +20,7 @@ class ClientTest extends TestCase
     {
         $client = $this->mockApiClient(Client::class);
 
-        $client->expects()->httpGet('cgi-bin/getcallbackip')->andReturn('mock-result')->once();
+        $client->expects()->httpGet('cgi-bin/getcallbackip')->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->getCallbackIp());
     }

--- a/tests/Work/Chat/ClientTest.php
+++ b/tests/Work/Chat/ClientTest.php
@@ -19,21 +19,21 @@ class ClientTest extends TestCase
     public function testGet()
     {
         $client = $this->mockApiClient(Client::class);
-        $client->expects()->httpGet('cgi-bin/appchat/get', ['chatid' => 'overtrue'])->andReturn('mock-result')->once();
+        $client->expects()->httpGet('cgi-bin/appchat/get', ['chatid' => 'overtrue'])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->get('overtrue'));
     }
 
     public function testCreate()
     {
         $client = $this->mockApiClient(Client::class);
-        $client->expects()->httpPostJson('cgi-bin/appchat/create', ['foo' => 'bar'])->andReturn('mock-result')->once();
+        $client->expects()->httpPostJson('cgi-bin/appchat/create', ['foo' => 'bar'])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->create(['foo' => 'bar']));
     }
 
     public function testUpdate()
     {
         $client = $this->mockApiClient(Client::class);
-        $client->expects()->httpPostJson('cgi-bin/appchat/update', ['chatid' => 'overtrue', 'foo' => 'bar'])->andReturn('mock-result')->once();
+        $client->expects()->httpPostJson('cgi-bin/appchat/update', ['chatid' => 'overtrue', 'foo' => 'bar'])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->update('overtrue', ['foo' => 'bar']));
     }
 
@@ -41,7 +41,7 @@ class ClientTest extends TestCase
     {
         $client = $this->mockApiClient(Client::class);
 
-        $client->expects()->httpPostJson('cgi-bin/appchat/send', ['foo' => 'bar'])->andReturn('mock-result')->once();
+        $client->expects()->httpPostJson('cgi-bin/appchat/send', ['foo' => 'bar'])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->send(['foo' => 'bar']));
     }

--- a/tests/Work/Crm/ClientTest.php
+++ b/tests/Work/Crm/ClientTest.php
@@ -19,7 +19,7 @@ class ClientTest extends TestCase
     public function testGetExternalContact()
     {
         $client = $this->mockApiClient(Client::class);
-        $client->expects()->httpGet('cgi-bin/crm/get_external_contact', ['external_userid' => 'mock-userid'])->andReturn('mock-result')->once();
+        $client->expects()->httpGet('cgi-bin/crm/get_external_contact', ['external_userid' => 'mock-userid'])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->getExternalContact('mock-userid'));
     }
 }

--- a/tests/Work/Department/ClientTest.php
+++ b/tests/Work/Department/ClientTest.php
@@ -21,7 +21,7 @@ class ClientTest extends TestCase
         $client = $this->mockApiClient(Client::class);
         $client->expects()->httpPostJson('cgi-bin/department/create', [
             'foo' => 'bar',
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->create(['foo' => 'bar']));
     }
 
@@ -31,7 +31,7 @@ class ClientTest extends TestCase
         $client->expects()->httpPostJson('cgi-bin/department/update', [
             'id' => 3,
             'foo' => 'bar',
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->update(3, ['foo' => 'bar']));
     }
 
@@ -40,7 +40,7 @@ class ClientTest extends TestCase
         $client = $this->mockApiClient(Client::class);
         $client->expects()->httpGet('cgi-bin/department/delete', [
             'id' => 3,
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->delete(3));
     }
 
@@ -49,12 +49,12 @@ class ClientTest extends TestCase
         $client = $this->mockApiClient(Client::class);
         $client->expects()->httpGet('cgi-bin/department/list', [
             'id' => null,
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->list());
 
         $client->expects()->httpGet('cgi-bin/department/list', [
             'id' => 3,
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->list(3));
     }
 }

--- a/tests/Work/Jssdk/ClientTest.php
+++ b/tests/Work/Jssdk/ClientTest.php
@@ -41,7 +41,7 @@ class ClientTest extends TestCase
         $response = new \EasyWeChat\Kernel\Http\Response(200, [], json_encode($ticket));
 
         // no refresh and cached
-        $cache->expects()->has($cacheKey)->once()->andReturn(true);
+        $cache->expects()->has($cacheKey)->andReturn(true);
         $cache->expects()->get($cacheKey)->andReturn($ticket);
 
         $this->assertSame($ticket, $client->getTicket());
@@ -50,15 +50,15 @@ class ClientTest extends TestCase
         $cache->expects()->has($cacheKey)->twice()->andReturn(false, true);
         $cache->expects()->get($cacheKey)->never();
         $cache->expects()->set($cacheKey, $ticket, $ticket['expires_in'] - 500);
-        $client->expects()->requestRaw('https://qyapi.weixin.qq.com/cgi-bin/get_jsapi_ticket', 'GET', ['query' => ['type' => 'jsapi']])->andReturn($response)->once();
+        $client->expects()->requestRaw('https://qyapi.weixin.qq.com/cgi-bin/get_jsapi_ticket', 'GET', ['query' => ['type' => 'jsapi']])->andReturn($response);
 
         $this->assertSame($ticket, $client->getTicket());
 
         // with refresh and cached
-        $cache->expects()->has($cacheKey)->once()->andReturn(true);
+        $cache->expects()->has($cacheKey)->andReturn(true);
         $cache->expects()->get($cacheKey)->never();
         $cache->expects()->set($cacheKey, $ticket, $ticket['expires_in'] - 500);
-        $client->expects()->requestRaw('https://qyapi.weixin.qq.com/cgi-bin/get_jsapi_ticket', 'GET', ['query' => ['type' => 'jsapi']])->andReturn($response)->once();
+        $client->expects()->requestRaw('https://qyapi.weixin.qq.com/cgi-bin/get_jsapi_ticket', 'GET', ['query' => ['type' => 'jsapi']])->andReturn($response);
 
         $this->assertSame($ticket, $client->getTicket(true));
     }

--- a/tests/Work/Media/ClientTest.php
+++ b/tests/Work/Media/ClientTest.php
@@ -30,7 +30,7 @@ class ClientTest extends TestCase
             'query' => [
                 'media_id' => $mediaId,
             ],
-        ])->andReturn($imageResponse)->once();
+        ])->andReturn($imageResponse);
 
         $this->assertSame(['error' => 'invalid media id hits.'], $client->get($mediaId));
 
@@ -40,7 +40,7 @@ class ClientTest extends TestCase
             'query' => [
                 'media_id' => $mediaId,
             ],
-        ])->andReturn($imageResponse)->once();
+        ])->andReturn($imageResponse);
 
         $this->assertInstanceOf(StreamResponse::class, $client->get($mediaId));
     }

--- a/tests/Work/Menu/ClientTest.php
+++ b/tests/Work/Menu/ClientTest.php
@@ -20,21 +20,21 @@ class ClientTest extends TestCase
     public function testGet()
     {
         $client = $this->mockApiClient(Client::class, [], new ServiceContainer(['agent_id' => 203874]));
-        $client->expects()->httpGet('cgi-bin/menu/get', ['agentid' => 203874])->andReturn('mock-result')->once();
+        $client->expects()->httpGet('cgi-bin/menu/get', ['agentid' => 203874])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->get());
     }
 
     public function testCreate()
     {
         $client = $this->mockApiClient(Client::class, [], new ServiceContainer(['agent_id' => 203874]));
-        $client->expects()->httpPostJson('cgi-bin/menu/create', ['foo' => 'bar'], ['agentid' => 203874])->andReturn('mock-result')->once();
+        $client->expects()->httpPostJson('cgi-bin/menu/create', ['foo' => 'bar'], ['agentid' => 203874])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->create(['foo' => 'bar']));
     }
 
     public function testDelete()
     {
         $client = $this->mockApiClient(Client::class, [], new ServiceContainer(['agent_id' => 203874]));
-        $client->expects()->httpGet('cgi-bin/menu/delete', ['agentid' => 203874])->andReturn('mock-result')->once();
+        $client->expects()->httpGet('cgi-bin/menu/delete', ['agentid' => 203874])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->delete());
     }
 }

--- a/tests/Work/MiniProgram/Auth/ClientTest.php
+++ b/tests/Work/MiniProgram/Auth/ClientTest.php
@@ -28,7 +28,7 @@ class ClientTest extends TestCase
         $client->expects()->httpGet('cgi-bin/miniprogram/jscode2session', [
             'js_code' => 'js-code',
             'grant_type' => 'authorization_code',
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->session('js-code'));
     }

--- a/tests/Work/User/ClientTest.php
+++ b/tests/Work/User/ClientTest.php
@@ -19,38 +19,38 @@ class ClientTest extends TestCase
     public function testCreate()
     {
         $client = $this->mockApiClient(Client::class);
-        $client->expects()->httpPostJson('cgi-bin/user/create', ['foo' => 'bar'])->andReturn('mock-result')->once();
+        $client->expects()->httpPostJson('cgi-bin/user/create', ['foo' => 'bar'])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->create(['foo' => 'bar']));
     }
 
     public function testUpdate()
     {
         $client = $this->mockApiClient(Client::class);
-        $client->expects()->httpPostJson('cgi-bin/user/update', ['userid' => 'overtrue', 'foo' => 'bar'])->andReturn('mock-result')->once();
+        $client->expects()->httpPostJson('cgi-bin/user/update', ['userid' => 'overtrue', 'foo' => 'bar'])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->update('overtrue', ['foo' => 'bar']));
     }
 
     public function testGet()
     {
         $client = $this->mockApiClient(Client::class);
-        $client->expects()->httpGet('cgi-bin/user/get', ['userid' => 'overtrue'])->andReturn('mock-result')->once();
+        $client->expects()->httpGet('cgi-bin/user/get', ['userid' => 'overtrue'])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->get('overtrue'));
     }
 
     public function testDelete()
     {
         $client = $this->mockApiClient(Client::class, 'batchDelete');
-        $client->expects()->httpGet('cgi-bin/user/delete', ['userid' => 'overtrue'])->andReturn('mock-result')->once();
+        $client->expects()->httpGet('cgi-bin/user/delete', ['userid' => 'overtrue'])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->delete('overtrue'));
 
-        $client->expects()->batchDelete(['overtrue', 'foo'])->andReturn('mock-result')->once();
+        $client->expects()->batchDelete(['overtrue', 'foo'])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->delete(['overtrue', 'foo']));
     }
 
     public function testBatchDelete()
     {
         $client = $this->mockApiClient(Client::class);
-        $client->expects()->httpPostJson('cgi-bin/user/batchdelete', ['useridlist' => ['overtrue', 'foo']])->andReturn('mock-result')->once();
+        $client->expects()->httpPostJson('cgi-bin/user/batchdelete', ['useridlist' => ['overtrue', 'foo']])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->batchDelete(['overtrue', 'foo']));
     }
 
@@ -60,13 +60,13 @@ class ClientTest extends TestCase
         $client->expects()->httpGet('cgi-bin/user/simplelist', [
             'department_id' => 14,
             'fetch_child' => 0,
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->getDepartmentUsers(14));
 
         $client->expects()->httpGet('cgi-bin/user/simplelist', [
             'department_id' => 15,
             'fetch_child' => 1,
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->getDepartmentUsers(15, true));
     }
 
@@ -76,13 +76,13 @@ class ClientTest extends TestCase
         $client->expects()->httpGet('cgi-bin/user/list', [
             'department_id' => 18,
             'fetch_child' => 0,
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->getDetailedDepartmentUsers(18));
 
         $client->expects()->httpGet('cgi-bin/user/list', [
             'department_id' => 18,
             'fetch_child' => 1,
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->getDetailedDepartmentUsers(18, true));
     }
 
@@ -90,11 +90,11 @@ class ClientTest extends TestCase
     {
         $client = $this->mockApiClient(Client::class);
         $client->expects()->httpPostJson('cgi-bin/user/convert_to_openid', ['userid' => 'overtrue', 'agentid' => null])
-                        ->andReturn('mock-result')->once();
+                        ->andReturn('mock-result');
         $this->assertSame('mock-result', $client->userIdToOpenid('overtrue'));
 
         $client->expects()->httpPostJson('cgi-bin/user/convert_to_openid', ['userid' => 'overtrue', 'agentid' => 39202])
-            ->andReturn('mock-result')->once();
+            ->andReturn('mock-result');
         $this->assertSame('mock-result', $client->userIdToOpenid('overtrue', 39202));
     }
 
@@ -102,14 +102,14 @@ class ClientTest extends TestCase
     {
         $client = $this->mockApiClient(Client::class);
         $client->expects()->httpPostJson('cgi-bin/user/convert_to_userid', ['openid' => 'mock-openid'])
-            ->andReturn('mock-result')->once();
+            ->andReturn('mock-result');
         $this->assertSame('mock-result', $client->openidToUserId('mock-openid'));
     }
 
     public function testAccept()
     {
         $client = $this->mockApiClient(Client::class);
-        $client->expects()->httpGet('cgi-bin/user/authsucc', ['userid' => 'overtrue'])->andReturn('mock-result')->once();
+        $client->expects()->httpGet('cgi-bin/user/authsucc', ['userid' => 'overtrue'])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->accept('overtrue'));
     }
 }

--- a/tests/Work/User/TagClientTest.php
+++ b/tests/Work/User/TagClientTest.php
@@ -20,11 +20,11 @@ class TagClientTest extends TestCase
     {
         $client = $this->mockApiClient(TagClient::class);
 
-        $client->expects()->httpPostJson('cgi-bin/tag/create', ['tagname' => '粉丝', 'tagid' => null])->andReturn('mock-result')->once();
+        $client->expects()->httpPostJson('cgi-bin/tag/create', ['tagname' => '粉丝', 'tagid' => null])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->create('粉丝'));
 
         // with id
-        $client->expects()->httpPostJson('cgi-bin/tag/create', ['tagname' => '粉丝', 'tagid' => 1])->andReturn('mock-result')->once();
+        $client->expects()->httpPostJson('cgi-bin/tag/create', ['tagname' => '粉丝', 'tagid' => 1])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->create('粉丝', 1));
     }
 
@@ -32,7 +32,7 @@ class TagClientTest extends TestCase
     {
         $client = $this->mockApiClient(TagClient::class);
 
-        $client->expects()->httpGet('cgi-bin/tag/list')->andReturn('mock-result')->once();
+        $client->expects()->httpGet('cgi-bin/tag/list')->andReturn('mock-result');
         $this->assertSame('mock-result', $client->list());
     }
 
@@ -43,7 +43,7 @@ class TagClientTest extends TestCase
         $client->expects()->httpPostJson('cgi-bin/tag/update', [
             'tagid' => 12,
             'tagname' => '粉丝',
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->update(12, '粉丝'));
     }
@@ -54,7 +54,7 @@ class TagClientTest extends TestCase
 
         $client->expects()->httpGet('cgi-bin/tag/delete', [
             'tagid' => 12,
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->delete(12));
     }
@@ -65,7 +65,7 @@ class TagClientTest extends TestCase
 
         $client->expects()->httpGet('cgi-bin/tag/get', [
             'tagid' => 12,
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->get(12));
     }
@@ -78,7 +78,7 @@ class TagClientTest extends TestCase
             'tagid' => 12,
             'userlist' => ['foo', 'bar'],
             'partylist' => [],
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->tagUsers(12, ['foo', 'bar']));
     }
@@ -91,7 +91,7 @@ class TagClientTest extends TestCase
             'tagid' => 12,
             'userlist' => ['foo', 'bar'],
             'partylist' => [],
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->untagUsers(12, ['foo', 'bar']));
     }
@@ -104,7 +104,7 @@ class TagClientTest extends TestCase
             'tagid' => 12,
             'userlist' => [],
             'partylist' => [14, 26],
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->tagDepartments(12, [14, 26]));
     }
@@ -117,7 +117,7 @@ class TagClientTest extends TestCase
             'tagid' => 12,
             'userlist' => [],
             'partylist' => [14, 26],
-        ])->andReturn('mock-result')->once();
+        ])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->untagDepartments(12, [14, 26]));
     }


### PR DESCRIPTION
* Replace deprecated `shouldDeferMissing` method with `makePartial`.
* Remove redundant `->once()` calls, as `->once()` is called by default.

[`expects`](https://github.com/mockery/mockery/blob/master/library/Mockery/Mock.php#L257) method
```php
    /**
     * @param mixed $something  String method name (optional)
     * @return \Mockery\ExpectationInterface|\Mockery\Expectation|ExpectsHigherOrderMessage
     */
    public function expects($something = null)
    {
        if (is_string($something)) {
            return $this->shouldReceive($something)->once();
        }
        return new ExpectsHigherOrderMessage($this);
    }
```

[`ExpectsHigherOrderMessage`](https://github.com/mockery/mockery/blob/287bf49b90ac9d82a778b1c8f51342b560daff3b/library/Mockery/ExpectsHigherOrderMessage.php#L32) class
```php
    /**
     * @return \Mockery\Expectation
     */
    public function __call($method, $args)
    {
        $expectation = parent::__call($method, $args);
        return $expectation->once();
    }
```

When we call any method after `expects()`, `once()` will be called at once. 
