### PR TITLE
消息加解密方式增加判断

### DIFF
--- a/src/MiniProgram/Application.php
+++ b/src/MiniProgram/Application.php
@@ -12,6 +12,7 @@
 namespace EasyWeChat\MiniProgram;
 
 use EasyWeChat\BasicService;
+use EasyWeChat\Kernel\ServerGuard;
 use EasyWeChat\Kernel\ServiceContainer;
 
 /**
@@ -73,4 +74,11 @@ class Application extends ServiceContainer
     {
         return $this->base->$method(...$args);
     }
+
+    /**
+     * @var array
+     */
+    protected $defaultConfig = [
+        'encryption_mode' => ServerGuard::ENCRYPTION_MODE_COMPATIBLE,
+    ];
 }

--- a/src/OfficialAccount/Application.php
+++ b/src/OfficialAccount/Application.php
@@ -12,6 +12,7 @@
 namespace EasyWeChat\OfficialAccount;
 
 use EasyWeChat\BasicService;
+use EasyWeChat\Kernel\ServerGuard;
 use EasyWeChat\Kernel\ServiceContainer;
 
 /**
@@ -77,5 +78,12 @@ class Application extends ServiceContainer
         BasicService\Media\ServiceProvider::class,
         BasicService\Url\ServiceProvider::class,
         BasicService\Jssdk\ServiceProvider::class,
+    ];
+
+    /**
+     * @var array
+     */
+    protected $defaultConfig = [
+        'encryption_mode' => ServerGuard::ENCRYPTION_MODE_COMPATIBLE,
     ];
 }

--- a/src/OpenPlatform/Application.php
+++ b/src/OpenPlatform/Application.php
@@ -11,6 +11,7 @@
 
 namespace EasyWeChat\OpenPlatform;
 
+use EasyWeChat\Kernel\ServerGuard;
 use EasyWeChat\Kernel\ServiceContainer;
 use EasyWeChat\MiniProgram\Encryptor;
 use EasyWeChat\OpenPlatform\Authorizer\Auth\AccessToken;
@@ -57,6 +58,7 @@ class Application extends ServiceContainer
             'timeout' => 5.0,
             'base_uri' => 'https://api.weixin.qq.com/',
         ],
+        'encryption_mode' => ServerGuard::ENCRYPTION_MODE_SAFE,
     ];
 
     /**
@@ -73,6 +75,7 @@ class Application extends ServiceContainer
         $application = new OfficialAccount($this->getAuthorizerConfig($appId, $refreshToken), $this->getReplaceServices($accessToken) + [
             'encryptor' => $this['encryptor'],
 
+            'encryption_mode' => ServerGuard::ENCRYPTION_MODE_SAFE,
             'account' => function ($app) {
                 return new AccountClient($app, $this);
             },
@@ -102,6 +105,7 @@ class Application extends ServiceContainer
                 return new Encryptor($this['config']['app_id'], $this['config']['token'], $this['config']['aes_key']);
             },
 
+            'encryption_mode' => ServerGuard::ENCRYPTION_MODE_SAFE,
             'auth' => function ($app) {
                 return new Client($app, $this);
             },

--- a/src/OpenWork/Application.php
+++ b/src/OpenWork/Application.php
@@ -11,6 +11,7 @@
 
 namespace EasyWeChat\OpenWork;
 
+use EasyWeChat\Kernel\ServerGuard;
 use EasyWeChat\Kernel\ServiceContainer;
 use EasyWeChat\OpenWork\Work\Application as Work;
 
@@ -44,6 +45,7 @@ class Application extends ServiceContainer
         'http' => [
             'base_uri' => 'https://qyapi.weixin.qq.com/',
         ],
+        'encryption_mode' => ServerGuard::ENCRYPTION_MODE_SAFE,
     ];
 
     /**

--- a/src/Work/Application.php
+++ b/src/Work/Application.php
@@ -11,6 +11,7 @@
 
 namespace EasyWeChat\Work;
 
+use EasyWeChat\Kernel\ServerGuard;
 use EasyWeChat\Kernel\ServiceContainer;
 use EasyWeChat\Work\MiniProgram\Application as MiniProgram;
 
@@ -69,6 +70,7 @@ class Application extends ServiceContainer
         'http' => [
             'base_uri' => 'https://qyapi.weixin.qq.com/',
         ],
+        'encryption_mode' => ServerGuard::ENCRYPTION_MODE_COMPATIBLE,
     ];
 
     /**


### PR DESCRIPTION
增加消息处理过程中的加解密方式判断，如果为安全模式则必须为加密后的内容。（原代码在安全模式下可以接收明文模式请求）
增加默认消息加解密方式配置，开放平台为默认安全模式，开发者模式接入默认为兼容模式，修改配置方式如下
增加 config  “encryption_mode”=>ServerGuard::ENCRYPTION_MODE_SAFE  