### PR TITLE
key not exists exception message

### DIFF
--- a/src/Payment/Application.php
+++ b/src/Payment/Application.php
@@ -183,7 +183,7 @@ class Application extends ServiceContainer
         $key = $this->inSandbox() ? $this['sandbox']->getKey() : $this['config']->key;
 
         if (empty($key)) {
-            throw new InvalidArgumentException("config key not exists.");
+            throw new InvalidArgumentException("config key Connot be empty.");
         }
 
         if (32 !== strlen($key)) {

--- a/src/Payment/Application.php
+++ b/src/Payment/Application.php
@@ -182,6 +182,10 @@ class Application extends ServiceContainer
 
         $key = $this->inSandbox() ? $this['sandbox']->getKey() : $this['config']->key;
 
+        if (empty($key)) {
+            throw new InvalidArgumentException("config key not exists.");
+        }
+
         if (32 !== strlen($key)) {
             throw new InvalidArgumentException(sprintf("'%s' should be 32 chars length.", $key));
         }


### PR DESCRIPTION
当key没设置值得时候或者不存在的时候；
异常信息放回的是`'' should be 32 chars length.`；不方便查看