### PR TITLE
config key not exists exception message

### DIFF
--- a/src/Payment/Application.php
+++ b/src/Payment/Application.php
@@ -183,7 +183,7 @@ class Application extends ServiceContainer
         $key = $this->inSandbox() ? $this['sandbox']->getKey() : $this['config']->key;
 
         if (empty($key)) {
-            throw new InvalidArgumentException("config key connot be empty.");
+            throw new InvalidArgumentException("config key should not empty.");
         }
 
         if (32 !== strlen($key)) {


### PR DESCRIPTION
当key没设置值得时候或者不存在的时候；
提示消息`config key connot be empty`;
单词错误改为`config key should not empty.`