### PR TITLE
Required psr/simple-cache

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
         "monolog/monolog": "^1.22",
         "overtrue/socialite": "~2.0",
         "pimple/pimple": "^3.0",
+        "psr/simple-cache": "^1.0",
         "symfony/cache": "^3.3 || ^4.0",
         "symfony/http-foundation": "^2.7 || ^3.0 || ^4.0",
         "symfony/psr-http-message-bridge": "^0.3 || ^1.0"


### PR DESCRIPTION
`symfony/cache` 4.3+ 移除了 `psr/simple-cache`

Fix: #1551 
Fix: #1552 