### PR TITLE
给订单查询增加选传参数`attach`

### DIFF
--- a/src/Payment/Order/Client.php
+++ b/src/Payment/Order/Client.php
@@ -41,15 +41,17 @@ class Client extends BaseClient
      * Query order by out trade number.
      *
      * @param string $number
+     * @param string $attach
      *
      * @return \Psr\Http\Message\ResponseInterface|\EasyWeChat\Kernel\Support\Collection|array|object|string
      *
      * @throws \EasyWeChat\Kernel\Exceptions\InvalidConfigException
      */
-    public function queryByOutTradeNumber(string $number)
+    public function queryByOutTradeNumber(string $number, string $attach = '')
     {
         return $this->query([
             'out_trade_no' => $number,
+            'attach' => $attach
         ]);
     }
 
@@ -57,15 +59,17 @@ class Client extends BaseClient
      * Query order by transaction id.
      *
      * @param string $transactionId
+     * @param string $attach
      *
      * @return \Psr\Http\Message\ResponseInterface|\EasyWeChat\Kernel\Support\Collection|array|object|string
      *
      * @throws \EasyWeChat\Kernel\Exceptions\InvalidConfigException
      */
-    public function queryByTransactionId(string $transactionId)
+    public function queryByTransactionId(string $transactionId, string $attach = '')
     {
         return $this->query([
             'transaction_id' => $transactionId,
+            'attach' => $attach
         ]);
     }
 


### PR DESCRIPTION
https://pay.weixin.qq.com/wiki/doc/api/native.php?chapter=9_2
> 以下字段在return_code 、result_code、trade_state都为SUCCESS时有返回 ，如trade_state不为 SUCCESS，则只返回out_trade_no（必传）和attach（选传）。