### PR TITLE
fix bug

### DIFF
--- a/src/Kernel/BaseClient.php
+++ b/src/Kernel/BaseClient.php
@@ -16,9 +16,9 @@ use EasyWeChat\Kernel\Http\Response;
 use EasyWeChat\Kernel\Traits\HasHttpRequests;
 use GuzzleHttp\MessageFormatter;
 use GuzzleHttp\Middleware;
-use Monolog\Logger;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Log\LogLevel;
 
 /**
  * Class BaseClient.
@@ -227,7 +227,7 @@ class BaseClient
     {
         $formatter = new MessageFormatter($this->app['config']['http.log_template'] ?? MessageFormatter::DEBUG);
 
-        return Middleware::log($this->app['logger'], $formatter, Logger::DEBUG);
+        return Middleware::log($this->app['logger'], $formatter, LogLevel::DEBUG);
     }
 
     /**


### PR DESCRIPTION
默认日志等级设置错误。

当前设置的`Monolog\Logger::DEBUG`值为`100`，与`GuzzleHttp\Middleware`类中的方法`public static function log(LoggerInterface $logger, MessageFormatter $formatter, $logLevel = LogLevel::INFO)`的参数`logLevel`类型也不一致。