### PR TITLE
Migrating GitHub Actions from HCL syntax to YAML syntax

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -1,9 +1,0 @@
-workflow "Main" {
-  on = "push"
-  resolves = ["PHPStan"]
-}
-
-action "PHPStan" {
-  uses = "docker://oskarstark/phpstan-ga"
-  args = "analyse --no-progress"
-}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,16 @@
+name: Lint
+on: [push, pull_request]
+
+jobs:
+  phpstan:
+    name: PHPStan
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - uses: docker://php:7.3-cli
+    - name: Install Dependencies
+      run: composer require phpstan/phpstan --no-progress
+      # TODO: change to the following line after phpstan have been added to composer.json
+      # run: composer install --no-progress
+    - name: Run PHPStan
+      run: ./vendor/bin/phpstan analyse --no-progress


### PR DESCRIPTION
Use the new syntax of GitHub actions, HCL syntax in GitHub Actions will be deprecated on September 30, 2019