### PR TITLE
Remove support for PHP 7.0

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,9 +8,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Install Dependencies
-      run: composer require phpstan/phpstan --no-progress
-      # TODO: change to the following line after phpstan have been added to composer.json
-      # run: composer install --no-progress
+      run: composer install --no-progress
     - name: Run PHPStan
       run: ./vendor/bin/phpstan analyse --no-progress
 
@@ -20,8 +18,6 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Install Dependencies
-      run: composer require friendsofphp/php-cs-fixer --no-progress
-      # TODO: change to the following line after php-cs-fixer have been added to composer.json
-      # run: composer install --no-progress
+      run: composer install --no-progress
     - name: Run PHP-CS-Fxier
       run: ./vendor/bin/php-cs-fixer fix --dry-run --diff 1>&2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php_version: ['7.0', '7.1', '7.2', '7.3']
+        php_version: ['7.1', '7.2', '7.3']
     container:
       image: php:${{ matrix.php_version }}-cli
     steps:
@@ -28,8 +28,6 @@ jobs:
         cp /usr/local/etc/php/php.ini-development /usr/local/etc/php/php.ini 
 
         # Install deps
-        # TODO: remove this after PHP7.0 is unsupported.
-        composer remove symfony/event-dispatcher --no-progress --dev -n
-        # composer install --no-progress --prefer-dist
+        composer install --no-progress --prefer-dist
     - name: Run PHPUnit
       run: ./vendor/bin/phpunit

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 ## Requirement
 
-1. PHP >= 7.0
+1. PHP >= 7.1
 2. **[Composer](https://getcomposer.org/)**
 3. openssl 拓展
 4. fileinfo 拓展（素材管理模块需要用到）

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": ">=7.0",
+        "php": ">=7.1",
         "ext-fileinfo": "*",
         "ext-openssl": "*",
         "ext-simplexml": "*",
@@ -33,7 +33,9 @@
         "mikey179/vfsStream": "^1.6",
         "mockery/mockery": "^1.0",
         "phpunit/phpunit": "~6.5",
-        "symfony/event-dispatcher": "^4.0"
+        "symfony/event-dispatcher": "^4.0",
+        "phpstan/phpstan": "^0.11.12",
+        "friendsofphp/php-cs-fixer": "^2.15"
     },
     "suggest": {
         "symfony/event-dispatcher": "Required to use EasyWeChat events component (^4.0)."
@@ -55,6 +57,6 @@
     "scripts": {
         "test": "vendor/bin/phpunit",
         "phpcs": "vendor/bin/php-cs-fixer fix",
-        "phpstan": "docker run -v \"$PWD:/usr/src/app\" --rm oskarstark/phpstan-ga:latest analyse"
+        "phpstan": "vendor/bin/phpstan analyse"
     }
 }


### PR DESCRIPTION
放弃对已结束生命周期对 PHP 7.0 的支持。

https://www.php.net/supported-versions.php