### PR TITLE
添加 symfony/event-dispatcher 到依赖

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
         "pimple/pimple": "^3.0",
         "psr/simple-cache": "^1.0",
         "symfony/cache": "^3.3 || ^4.3",
+        "symfony/event-dispatcher": "^4.3",
         "symfony/http-foundation": "^2.7 || ^3.0 || ^4.0",
         "symfony/psr-http-message-bridge": "^0.3 || ^1.0"
     },
@@ -33,12 +34,8 @@
         "mikey179/vfsStream": "^1.6",
         "mockery/mockery": "^1.0",
         "phpunit/phpunit": "~6.5",
-        "symfony/event-dispatcher": "^4.0",
         "phpstan/phpstan": "^0.11.12",
         "friendsofphp/php-cs-fixer": "^2.15"
-    },
-    "suggest": {
-        "symfony/event-dispatcher": "Required to use EasyWeChat events component (^4.0)."
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "symfony/psr-http-message-bridge": "^0.3 || ^1.0"
     },
     "require-dev": {
-        "mikey179/vfsStream": "^1.6",
+        "mikey179/vfsstream": "^1.6",
         "mockery/mockery": "^1.0",
         "phpunit/phpunit": "~6.5",
         "phpstan/phpstan": "^0.11.12",

--- a/composer.json
+++ b/composer.json
@@ -31,11 +31,11 @@
         "symfony/psr-http-message-bridge": "^0.3 || ^1.0"
     },
     "require-dev": {
+        "friendsofphp/php-cs-fixer": "^2.15",
         "mikey179/vfsstream": "^1.6",
         "mockery/mockery": "^1.0",
-        "phpunit/phpunit": "~6.5",
         "phpstan/phpstan": "^0.11.12",
-        "friendsofphp/php-cs-fixer": "^2.15"
+        "phpunit/phpunit": "~6.5"
     },
     "autoload": {
         "psr-4": {
@@ -52,8 +52,8 @@
         }
     },
     "scripts": {
-        "test": "vendor/bin/phpunit",
         "phpcs": "vendor/bin/php-cs-fixer fix",
-        "phpstan": "vendor/bin/phpstan analyse"
+        "phpstan": "vendor/bin/phpstan analyse",
+        "test": "vendor/bin/phpunit"
     }
 }


### PR DESCRIPTION
修复了因安装了 4.3 以下版本的 `symfony/event-dispatcher` 导致的 `Illegal offset type in isset or empty` 错误。