### PR TITLE
Fix is_readable function throw Warning

### DIFF
--- a/src/Kernel/Support/File.php
+++ b/src/Kernel/Support/File.php
@@ -97,8 +97,10 @@ class File
      */
     public static function getStreamExt($stream)
     {
+        $ext = self::getExtBySignature($stream);
+
         try {
-            if (is_readable($stream)) {
+            if (empty($ext) && is_readable($stream)) {
                 $stream = file_get_contents($stream);
             }
         } catch (\Exception $e) {
@@ -108,7 +110,7 @@ class File
 
         $mime = strstr($fileInfo->buffer($stream), ';', true);
 
-        return isset(self::$extensionMap[$mime]) ? self::$extensionMap[$mime] : self::getExtBySignature($stream);
+        return isset(self::$extensionMap[$mime]) ? self::$extensionMap[$mime] : $ext;
     }
 
     /**


### PR DESCRIPTION
当 `$stream` 是二进制字符串时，`is_readable` 函数会抛出 `Warning` 。

```
Warning: is_readable() expects parameter 1 to be a valid path, string given
```