### PR TITLE
QQ小程序接口支持

### DIFF
--- a/src/Kernel/AccessToken.php
+++ b/src/Kernel/AccessToken.php
@@ -89,7 +89,7 @@ abstract class AccessToken implements AccessTokenInterface
      * @throws \EasyWeChat\Kernel\Exceptions\InvalidArgumentException
      * @throws \EasyWeChat\Kernel\Exceptions\RuntimeException
      */
-    public function getRefreshedToken(): array
+    public function getRefreshedToken() : array
     {
         return $this->getToken(true);
     }
@@ -105,7 +105,7 @@ abstract class AccessToken implements AccessTokenInterface
      * @throws \EasyWeChat\Kernel\Exceptions\InvalidArgumentException
      * @throws \EasyWeChat\Kernel\Exceptions\RuntimeException
      */
-    public function getToken(bool $refresh = false): array
+    public function getToken(bool $refresh = false) : array
     {
         $cacheKey = $this->getCacheKey();
         $cache = $this->getCache();
@@ -134,7 +134,7 @@ abstract class AccessToken implements AccessTokenInterface
      * @throws \EasyWeChat\Kernel\Exceptions\RuntimeException
      * @throws \Psr\SimpleCache\InvalidArgumentException
      */
-    public function setToken(string $token, int $lifetime = 7200): AccessTokenInterface
+    public function setToken(string $token, int $lifetime = 7200) : AccessTokenInterface
     {
         $this->getCache()->set($this->getCacheKey(), [
             $this->tokenKey => $token,
@@ -157,7 +157,7 @@ abstract class AccessToken implements AccessTokenInterface
      * @throws \EasyWeChat\Kernel\Exceptions\InvalidArgumentException
      * @throws \EasyWeChat\Kernel\Exceptions\RuntimeException
      */
-    public function refresh(): AccessTokenInterface
+    public function refresh() : AccessTokenInterface
     {
         $this->getToken(true);
 
@@ -181,7 +181,7 @@ abstract class AccessToken implements AccessTokenInterface
         $formatted = $this->castResponseToType($response, $this->app['config']->get('response_type'));
 
         if (empty($result[$this->tokenKey])) {
-            throw new HttpException('Request access_token fail: '.json_encode($result, JSON_UNESCAPED_UNICODE), $response, $formatted);
+            throw new HttpException('Request access_token fail: ' . json_encode($result, JSON_UNESCAPED_UNICODE), $response, $formatted);
         }
 
         return $toArray ? $result : $formatted;
@@ -199,7 +199,7 @@ abstract class AccessToken implements AccessTokenInterface
      * @throws \EasyWeChat\Kernel\Exceptions\InvalidArgumentException
      * @throws \EasyWeChat\Kernel\Exceptions\RuntimeException
      */
-    public function applyToRequest(RequestInterface $request, array $requestOptions = []): RequestInterface
+    public function applyToRequest(RequestInterface $request, array $requestOptions = []) : RequestInterface
     {
         parse_str($request->getUri()->getQuery(), $query);
 
@@ -218,7 +218,7 @@ abstract class AccessToken implements AccessTokenInterface
      * @throws \EasyWeChat\Kernel\Exceptions\InvalidArgumentException
      * @throws \GuzzleHttp\Exception\GuzzleException
      */
-    protected function sendRequest(array $credentials): ResponseInterface
+    protected function sendRequest(array $credentials) : ResponseInterface
     {
         $options = [
             ('GET' === $this->requestMethod) ? 'query' : 'json' => $credentials,
@@ -232,7 +232,7 @@ abstract class AccessToken implements AccessTokenInterface
      */
     protected function getCacheKey()
     {
-        return $this->cachePrefix.md5(json_encode($this->getCredentials()));
+        return $this->cachePrefix . md5(json_encode($this->getCredentials()));
     }
 
     /**
@@ -246,7 +246,7 @@ abstract class AccessToken implements AccessTokenInterface
      * @throws \EasyWeChat\Kernel\Exceptions\InvalidArgumentException
      * @throws \EasyWeChat\Kernel\Exceptions\RuntimeException
      */
-    protected function getQuery(): array
+    protected function getQuery() : array
     {
         return [$this->queryName ?? $this->tokenKey => $this->getToken()[$this->tokenKey]];
     }
@@ -256,8 +256,11 @@ abstract class AccessToken implements AccessTokenInterface
      *
      * @throws \EasyWeChat\Kernel\Exceptions\InvalidArgumentException
      */
-    public function getEndpoint(): string
+    public function getEndpoint() : string
     {
+        if ($this->app['config']->get('http')['get_token_uri']) {
+            $this->endpointToGetToken = $this->app['config']->get('http')['get_token_uri'];
+        }
         if (empty($this->endpointToGetToken)) {
             throw new InvalidArgumentException('No endpoint for access token request.');
         }
@@ -278,5 +281,5 @@ abstract class AccessToken implements AccessTokenInterface
      *
      * @return array
      */
-    abstract protected function getCredentials(): array;
+    abstract protected function getCredentials() : array;
 }

--- a/src/Kernel/AccessToken.php
+++ b/src/Kernel/AccessToken.php
@@ -258,9 +258,10 @@ abstract class AccessToken implements AccessTokenInterface
      */
     public function getEndpoint() : string
     {
-        if ($this->app['config']->get('http')['get_token_uri']) {
-            $this->endpointToGetToken = $this->app['config']->get('http')['get_token_uri'];
+        if ($this->app['config']->has('http.base_uri') && strpos($this->app['config']->get('http.base_uri'), 'api.q.qq.com') !== false) {
+            $this->endpointToGetToken = $this->app['config']->get('http.base_uri') . 'api/getToken';
         }
+
         if (empty($this->endpointToGetToken)) {
             throw new InvalidArgumentException('No endpoint for access token request.');
         }

--- a/src/Payment/Order/Client.php
+++ b/src/Payment/Order/Client.php
@@ -50,7 +50,12 @@ class Client extends BaseClient
             return $this->request($this->wrap('pay/contractorder'), $params);
         }
 
-        return $this->request($this->wrap('pay/unifiedorder'), $params);
+        $path = $this->wrap('pay/unifiedorder');
+        if ($this->app['config']->has('http.base_uri') && strpos($this->app['config']->get('http.base_uri'), 'qpay.qq.com') !== false) {
+            $path = 'cgi-bin/pay/qpay_close_order.cgi';
+        }
+
+        return $this->request($path, $params);
     }
 
     /**


### PR DESCRIPTION
实现QQ小程序服务端功能的时候，可以直接使用`EasyWeChat`的`MiniProgram`目录下的接口，只需要在初始化的时候指定`base_uri`为QQ小程序的接口域名。

QQ小程序中`EasyWeChat`调用示例：

- 登录：
```
use EasyWeChat\Factory;

$config = [
    'http' => [
          'timeout' => 30.0,
          'base_uri' => 'https://api.q.qq.com/'
    ],                 
    'app_id' => 'QQ小程序appid',                                                 
    'secret' => 'QQ小程序appsecret',      
    // 下面为可选项
    // 指定 API 调用返回结果的类型：array(default)/collection/object/raw/自定义类名
    'response_type' => 'array',

    'log' => [
        'level' => 'debug',
        'file' => __DIR__.'/qq.log',
    ],
];

$app = Factory::miniProgram($config);

// $code为QQ小程序调用`wx.login`成功后获取到的登录信息。
$app->auth->session(string $code);
```

- QQ支付统一下单
```
use EasyWeChat\Factory;

$config = [
    'http' => [
        'timeout' => 30.0,
        'base_uri' => 'https://qpay.qq.com/'
    ],
    'app_id'             => 'QQ小程序appid',
    'mch_id'             => 'QQ钱包商户号',
    'key'                => 'QQ钱包API秘钥',   

    // 如需使用敏感接口（如退款、发送红包等）需要配置 API 证书路径(登录商户平台下载 API 证书)
    'cert_path'          => 'path/to/your/cert.pem', // XXX: 绝对路径！！！！
    'key_path'           => 'path/to/your/key',      // XXX: 绝对路径！！！！

    'notify_url'         => '默认的订单回调地址',     // 你也可以在下单时单独设置来想覆盖它
];

$app = Factory::payment($config);

$result = $app->order->unify([
    'body' => '腾讯充值中心-QQ会员充值',
    'out_trade_no' => '20150806125346',
    'total_fee' => 88,
    'spbill_create_ip' => '123.12.12.123', // 可选，如不传该参数，SDK 将会自动获取相应 IP 地址
    'notify_url' => 'https://qpay.qq.com/pay.action', // 支付结果通知网址，如果不设置则会使用配置里的默认地址
    'trade_type' => 'JSAPI', // 请对应换成你的支付方式对应的值类型
    'openid' => 'oUpF8uMuAJO_M2pxb1Q9zNjWeS6o',
]);
```