### PR TITLE
修复小微商户关注配置功能bug (#1691)

### DIFF
--- a/src/MicroMerchant/MerchantConfig/Client.php
+++ b/src/MicroMerchant/MerchantConfig/Client.php
@@ -41,7 +41,7 @@ class Client extends BaseClient
             'sub_mch_id' => $subMchId ?: $this->app['config']->sub_mch_id,
         ];
 
-        if (!empty($subscribeAppid)) {
+        if (!empty($subscribeAppId)) {
             $params['subscribe_appid'] = $subscribeAppId;
         } else {
             $params['receipt_appid'] = $receiptAppId;


### PR DESCRIPTION
setFollowConfig 函数 参数名称 $subscribeAppId 和函数体内 调用的变量 $subscribeAppid  不一致 导致设置关注时会导致不能设置公众号appid的问题