### PR TITLE
添加小程序一次性订阅消息发送支持

### DIFF
--- a/src/MiniProgram/Application.php
+++ b/src/MiniProgram/Application.php
@@ -61,6 +61,7 @@ class Application extends ServiceContainer
         OCR\ServiceProvider::class,
         Soter\ServiceProvider::class,
         Mall\ServiceProvider::class,
+        SubscribeMessage\ServiceProvider::class,
         // Base services
         BasicService\Media\ServiceProvider::class,
         BasicService\ContentSecurity\ServiceProvider::class,

--- a/src/MiniProgram/Application.php
+++ b/src/MiniProgram/Application.php
@@ -38,6 +38,7 @@ use EasyWeChat\Kernel\ServiceContainer;
  * @property \EasyWeChat\BasicService\Media\Client              $media
  * @property \EasyWeChat\BasicService\ContentSecurity\Client    $content_security
  * @property \EasyWeChat\MiniProgram\Mall\ForwardsMall          $mall
+ * @property \EasyWeChat\MiniProgram\SubscribeMessage\Client    $subscribe_message
  */
 class Application extends ServiceContainer
 {

--- a/src/MiniProgram/SubscribeMessage/Client.php
+++ b/src/MiniProgram/SubscribeMessage/Client.php
@@ -64,7 +64,7 @@ class Client extends BaseClient
      *
      * @throws \EasyWeChat\Kernel\Exceptions\InvalidArgumentException
      */
-    private function formatMessage(array $data = [])
+    protected function formatMessage(array $data = [])
     {
         $params = array_merge($this->message, $data);
 
@@ -76,24 +76,10 @@ class Client extends BaseClient
             $params[$key] = empty($value) ? $this->message[$key] : $value;
         }
 
-        $params['data'] = $this->formatData($params['data']);
-
-        return $params;
-    }
-
-    /**
-     * @param array $data
-     *
-     * @return array
-     */
-    protected function formatData(array $data)
-    {
-        $formatted = [];
-
-        foreach ($data as $key => $value) {
+        foreach ($params['data'] as $key => $value) {
             if (is_array($value)) {
                 if (isset($value['value'])) {
-                    $formatted[$key] = $value;
+                    $params['data'][$key] = ['value' => $value['value']];
 
                     continue;
                 }
@@ -110,10 +96,10 @@ class Client extends BaseClient
                 ];
             }
 
-            $formatted[$key] = $value;
+            $params['data'][$key] = $value;
         }
 
-        return $formatted;
+        return $params;
     }
 
     /**

--- a/src/MiniProgram/SubscribeMessage/Client.php
+++ b/src/MiniProgram/SubscribeMessage/Client.php
@@ -1,0 +1,126 @@
+<?php
+
+/*
+ * This file is part of the overtrue/wechat.
+ *
+ * (c) overtrue <i@overtrue.me>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace EasyWeChat\MiniProgram\SubscribeMessage;
+
+use EasyWeChat\Kernel\BaseClient;
+use EasyWeChat\Kernel\Exceptions\InvalidArgumentException;
+use ReflectionClass;
+
+/**
+ * Class Client.
+ *
+ * @author hugo <rabbitzhang52@gmail.com>
+ */
+class Client extends BaseClient
+{
+    /**
+     * {@inheritdoc}.
+     */
+    protected $message = [
+        'touser' => '',
+        'template_id' => '',
+        'page' => '',
+        'data' => [],
+    ];
+
+    /**
+     * {@inheritdoc}.
+     */
+    protected $required = ['touser', 'template_id', 'data'];
+
+    /**
+     * Send a template message.
+     *
+     * @param array $data
+     *
+     * @return \Psr\Http\Message\ResponseInterface|\EasyWeChat\Kernel\Support\Collection|array|object|string
+     *
+     * @throws \EasyWeChat\Kernel\Exceptions\InvalidArgumentException
+     * @throws \EasyWeChat\Kernel\Exceptions\InvalidConfigException
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+    public function send(array $data = [])
+    {
+        $params = $this->formatMessage($data);
+
+        $this->restoreMessage();
+
+        return $this->httpPostJson('cgi-bin/message/subscribe/send', $params);
+    }
+
+    /**
+     * @param array $data
+     *
+     * @return array
+     *
+     * @throws \EasyWeChat\Kernel\Exceptions\InvalidArgumentException
+     */
+    private function formatMessage(array $data = [])
+    {
+        $params = array_merge($this->message, $data);
+
+        foreach ($params as $key => $value) {
+            if (in_array($key, $this->required, true) && empty($value) && empty($this->message[$key])) {
+                throw new InvalidArgumentException(sprintf('Attribute "%s" can not be empty!', $key));
+            }
+
+            $params[$key] = empty($value) ? $this->message[$key] : $value;
+        }
+
+        $params['data'] = $this->formatData($params['data']);
+
+        return $params;
+    }
+
+    /**
+     * @param array $data
+     *
+     * @return array
+     */
+    protected function formatData(array $data)
+    {
+        $formatted = [];
+
+        foreach ($data as $key => $value) {
+            if (is_array($value)) {
+                if (isset($value['value'])) {
+                    $formatted[$key] = $value;
+
+                    continue;
+                }
+
+                if (count($value) >= 1) {
+                    $value = [
+                        'value' => $value[0],
+//                        'color' => $value[1],// color unsupported
+                    ];
+                }
+            } else {
+                $value = [
+                    'value' => strval($value),
+                ];
+            }
+
+            $formatted[$key] = $value;
+        }
+
+        return $formatted;
+    }
+
+    /**
+     * Restore message.
+     */
+    protected function restoreMessage()
+    {
+        $this->message = (new ReflectionClass(static::class))->getDefaultProperties()['message'];
+    }
+}

--- a/src/MiniProgram/SubscribeMessage/ServiceProvider.php
+++ b/src/MiniProgram/SubscribeMessage/ServiceProvider.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the overtrue/wechat.
+ *
+ * (c) overtrue <i@overtrue.me>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace EasyWeChat\MiniProgram\SubscribeMessage;
+
+use Pimple\Container;
+use Pimple\ServiceProviderInterface;
+
+class ServiceProvider implements ServiceProviderInterface
+{
+    /**
+     * {@inheritdoc}.
+     */
+    public function register(Container $app)
+    {
+        $app['subscribe_message'] = function ($app) {
+            return new Client($app);
+        };
+    }
+}

--- a/tests/MiniProgram/SubscribeMessage/ClientTest.php
+++ b/tests/MiniProgram/SubscribeMessage/ClientTest.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the overtrue/wechat.
+ *
+ * (c) overtrue <i@overtrue.me>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace EasyWeChat\Tests\MiniProgram\SubscribeMessage;
+
+use EasyWeChat\Kernel\Exceptions\InvalidArgumentException;
+use EasyWeChat\MiniProgram\SubscribeMessage\Client;
+use EasyWeChat\Tests\TestCase;
+
+class ClientTest extends TestCase
+{
+    public function testSend()
+    {
+        $client = $this->mockApiClient(Client::class)->makePartial();
+
+        // without touser
+        try {
+            $client->send();
+        } catch (\Exception $e) {
+            $this->assertInstanceOf(InvalidArgumentException::class, $e);
+            $this->assertSame('Attribute "touser" can not be empty!', $e->getMessage());
+        }
+
+        // without template_id
+        try {
+            $client->send(['touser' => 'mock-openid']);
+        } catch (\Exception $e) {
+            $this->assertInstanceOf(InvalidArgumentException::class, $e);
+            $this->assertSame('Attribute "template_id" can not be empty!', $e->getMessage());
+        }
+
+        $client->expects()->httpPostJson('cgi-bin/message/subscribe/send', [
+            'touser' => 'mock-openid',
+            'template_id' => 'mock-template_id',
+            'page' => '',
+            'data' => ['thing1' => 'thing1.DATA'],
+        ])->andReturn('mock-result');
+        $this->assertSame('mock-result', $client->send(['touser' => 'mock-openid', 'template_id' => 'mock-template_id', 'data' => ['thing1' => 'thing1.DATA']]));
+    }
+}

--- a/tests/MiniProgram/SubscribeMessage/ClientTest.php
+++ b/tests/MiniProgram/SubscribeMessage/ClientTest.php
@@ -36,12 +36,19 @@ class ClientTest extends TestCase
             $this->assertInstanceOf(InvalidArgumentException::class, $e);
             $this->assertSame('Attribute "template_id" can not be empty!', $e->getMessage());
         }
+        // without data
+        try {
+            $client->send(['touser' => 'mock-openid', 'template_id' => 'mock-template_id']);
+        } catch (\Exception $e) {
+            $this->assertInstanceOf(InvalidArgumentException::class, $e);
+            $this->assertSame('Attribute "data" can not be empty!', $e->getMessage());
+        }
 
         $client->expects()->httpPostJson('cgi-bin/message/subscribe/send', [
             'touser' => 'mock-openid',
             'template_id' => 'mock-template_id',
             'page' => '',
-            'data' => ['thing1' => 'thing1.DATA'],
+            'data' => ['thing1' => ['value' => 'thing1.DATA']]
         ])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->send(['touser' => 'mock-openid', 'template_id' => 'mock-template_id', 'data' => ['thing1' => 'thing1.DATA']]));
     }

--- a/tests/MiniProgram/SubscribeMessage/ClientTest.php
+++ b/tests/MiniProgram/SubscribeMessage/ClientTest.php
@@ -48,7 +48,7 @@ class ClientTest extends TestCase
             'touser' => 'mock-openid',
             'template_id' => 'mock-template_id',
             'page' => '',
-            'data' => ['thing1' => ['value' => 'thing1.DATA']]
+            'data' => ['thing1' => ['value' => 'thing1.DATA']],
         ])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->send(['touser' => 'mock-openid', 'template_id' => 'mock-template_id', 'data' => ['thing1' => 'thing1.DATA']]));
     }

--- a/tests/MiniProgram/SubscribeMessage/ClientTest.php
+++ b/tests/MiniProgram/SubscribeMessage/ClientTest.php
@@ -36,6 +36,7 @@ class ClientTest extends TestCase
             $this->assertInstanceOf(InvalidArgumentException::class, $e);
             $this->assertSame('Attribute "template_id" can not be empty!', $e->getMessage());
         }
+
         // without data
         try {
             $client->send(['touser' => 'mock-openid', 'template_id' => 'mock-template_id']);
@@ -43,6 +44,67 @@ class ClientTest extends TestCase
             $this->assertInstanceOf(InvalidArgumentException::class, $e);
             $this->assertSame('Attribute "data" can not be empty!', $e->getMessage());
         }
+
+        // format message
+        $this->assertSame([
+            'touser' => 'mock-openid',
+            'template_id' => 'mock-template_id',
+            'page' => '',
+            'data' => ['thing1' => ['value' => 'thing1.DATA']],
+        ], $client->formatMessage([
+            'touser' => 'mock-openid',
+            'template_id' => 'mock-template_id',
+            'page' => '',
+            'data' => ['thing1' => 'thing1.DATA'],
+        ]));
+
+        $this->assertSame([
+            'touser' => 'mock-openid',
+            'template_id' => 'mock-template_id',
+            'page' => '',
+            'data' => ['thing1' => ['value' => 'thing1.DATA']],
+        ], $client->formatMessage([
+            'touser' => 'mock-openid',
+            'template_id' => 'mock-template_id',
+            'page' => '',
+            'data' => ['thing1' => ['thing1.DATA']],
+        ]));
+
+        $this->assertSame([
+            'touser' => 'mock-openid',
+            'template_id' => 'mock-template_id',
+            'page' => '',
+            'data' => ['thing1' => ['value' => 'thing1.DATA']],
+        ], $client->formatMessage([
+            'touser' => 'mock-openid',
+            'template_id' => 'mock-template_id',
+            'page' => '',
+            'data' => ['thing1' => ['thing1.DATA', 'ignore value']],
+        ]));
+
+        $this->assertSame([
+            'touser' => 'mock-openid',
+            'template_id' => 'mock-template_id',
+            'page' => '',
+            'data' => ['thing1' => ['value' => 'thing1.DATA']],
+        ], $client->formatMessage([
+            'touser' => 'mock-openid',
+            'template_id' => 'mock-template_id',
+            'page' => '',
+            'data' => ['thing1' => ['value' => 'thing1.DATA']],
+        ]));
+
+        $this->assertSame([
+            'touser' => 'mock-openid',
+            'template_id' => 'mock-template_id',
+            'page' => '',
+            'data' => ['thing1' => ['value' => 'thing1.DATA']],
+        ], $client->formatMessage([
+            'touser' => 'mock-openid',
+            'template_id' => 'mock-template_id',
+            'page' => '',
+            'data' => ['thing1' => ['value' => 'thing1.DATA', 'color' => 'ignore value']],
+        ]));
 
         $client->expects()->httpPostJson('cgi-bin/message/subscribe/send', [
             'touser' => 'mock-openid',

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -48,7 +48,7 @@ class TestCase extends BaseTestCase
     /**
      * Tear down the test case.
      */
-    public function tearDown()
+    public function tearDown():void
     {
         $this->finish();
         parent::tearDown();

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -48,7 +48,7 @@ class TestCase extends BaseTestCase
     /**
      * Tear down the test case.
      */
-    public function tearDown():void
+    public function tearDown()
     {
         $this->finish();
         parent::tearDown();


### PR DESCRIPTION
原有的小程序模板消息接口将于 2020 年 1 月 10 日下线，届时将无法使用此接口发送模板消息，请各位开发者注意及时调整接口

请参考以下资料：
[小程序模板消息能力调整通知](https://developers.weixin.qq.com/community/develop/doc/00008a8a7d8310b6bf4975b635a401)
[小程序一次性订阅消息发送接口](https://developers.weixin.qq.com/miniprogram/dev/api-backend/open-api/subscribe-message/subscribeMessage.send.html)
[一次性订阅消息开发经验](https://developers.weixin.qq.com/community/develop/article/doc/000e22321b8ef0b9bc491ae9c53c13)