### PR TITLE
修复TestCase,PHPStan错误

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -13,6 +13,5 @@ parameters:
         - '#Default value of the parameter \#2 \$depth \(INF.0\) of method EasyWeChat\\Kernel\\Support\\Arr::flatten\(\) is incompatible with type int#'
         - '#Access to an undefined property EasyWeChat\\Kernel\\ServiceContainer::\$extension#'
         - '#Method EasyWeChat\\Kernel\\Contracts\\MessageInterface::transformToXml\(\) invoked with 1 parameter, 0 required#'
-        - '#GuzzleHttp\\Exception\\GuzzleException is not subtype of Throwable#'
         - '#Method EasyWeChat\\Kernel\\Support\\Collection::__set_state\(\) should return object but returns array#'
         - '#Property EasyWeChat\\Payment\\Kernel\\BaseClient::\$app \(EasyWeChat\\Payment\\Application\) does not accept EasyWeChat\\MicroMerchant\\Application#'

--- a/tests/OpenPlatform/Authorizer/MiniProgram/Code/ClientTest.php
+++ b/tests/OpenPlatform/Authorizer/MiniProgram/Code/ClientTest.php
@@ -62,7 +62,7 @@ class ClientTest extends TestCase
     {
         $client = $this->mockApiClient(Client::class, [], new ServiceContainer(['app_id' => 'app-id']));
         $client->expects()->httpPostJson('wxa/submit_audit', ['item_list' => ['foo', 'bar'], 'feedback_info' => 'foo', 'feedback_stuff' => 'foo'])->andReturn('mock-result');
-        $this->assertSame('mock-result', $client->submitAudit(['foo', 'bar']));
+        $this->assertSame('mock-result', $client->submitAudit(['foo', 'bar'], 'foo', 'foo'));
     }
 
     public function testGetAuditStatus()


### PR DESCRIPTION
修复CompsoerTest失败

1. 修复`composer test` 模拟请求参数错误
2. 修复`composer phpstan`的`  Ignored error pattern #GuzzleHttp\\Exception\\GuzzleException is not subtype of Throwable# was not matched in reported errors.  `报错