### PR TITLE
PHP 7.1 end of life

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,6 @@ jobs:
       fail-fast: false
       matrix:
         php_version:
-          - 7.1
           - 7.2
           - 7.3
           - 7.4

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 ## Requirement
 
-1. PHP >= 7.1
+1. PHP >= 7.2
 2. **[Composer](https://getcomposer.org/)**
 3. openssl 拓展
 4. fileinfo 拓展（素材管理模块需要用到）

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": ">=7.1",
+        "php": ">=7.2",
         "ext-fileinfo": "*",
         "ext-openssl": "*",
         "ext-simplexml": "*",


### PR DESCRIPTION
PHP 7.1 is no longer supported. Users of this release should upgrade as soon as possible, as they may be exposed to unpatched security vulnerabilities.

Ref: https://www.php.net/supported-versions.php