### PR TITLE
优化appId可能被置空的问题

### DIFF
--- a/src/MicroMerchant/Application.php
+++ b/src/MicroMerchant/Application.php
@@ -104,7 +104,9 @@ class Application extends ServiceContainer
     public function setSubMchId(string $subMchId, string $appId = '')
     {
         $this['config']->set('sub_mch_id', $subMchId);
-        $this['config']->set('appid', $appId);
+        if ($appId) {
+            $this['config']->set('appid', $appId);
+        }
 
         return $this;
     }


### PR DESCRIPTION
缺省appId时会把原本配置中的appId置空