### PR TITLE
修复 AccessToken setToken 单元测试

### DIFF
--- a/tests/Kernel/AccessTokenTest.php
+++ b/tests/Kernel/AccessTokenTest.php
@@ -102,7 +102,7 @@ class AccessTokenTest extends TestCase
         $cache->expects()->set('mock-cache-key', [
             'access_token' => 'mock-token',
             'expires_in' => 7200,
-        ], 7200 - 500)->andReturn(true);
+        ], 7200)->andReturn(true);
         $result = $token->setToken('mock-token');
         $this->assertSame($token, $result);
 
@@ -111,7 +111,7 @@ class AccessTokenTest extends TestCase
         $cache->expects()->set('mock-cache-key', [
             'access_token' => 'mock-token',
             'expires_in' => 7000,
-        ], 7000 - 500)->andReturn(true);
+        ], 7000)->andReturn(true);
         $result = $token->setToken('mock-token', 7000);
         $this->assertSame($token, $result);
 
@@ -121,7 +121,7 @@ class AccessTokenTest extends TestCase
         $cache->expects()->set('mock-cache-key', [
             'access_token' => 'mock-token',
             'expires_in' => 7000,
-        ], 7000 - 500)->andReturn(false);
+        ], 7000)->andReturn(false);
         $token->setToken('mock-token', 7000);
     }
 


### PR DESCRIPTION
为了解决 #1761 ，在 commit https://github.com/overtrue/wechat/commit/7895e714a026147514774b079f6e3eb2b236c16a 中删除了 safeSeconds 属性。

单元测试中并未修改。

