### PR TITLE
修复无法获取商品状态的bug

### DIFF
--- a/src/MiniProgram/Broadcast/Client.php
+++ b/src/MiniProgram/Broadcast/Client.php
@@ -133,7 +133,7 @@ class Client extends BaseClient
             'goods_ids' => $goodsIdArray,
         ];
 
-        return $this->httpGet('wxa/business/getgoodswarehouse', $params);
+        return $this->httpPostJson('wxa/business/getgoodswarehouse', $params);
     }
     
     /**

--- a/tests/MiniProgram/Broadcast/ClientTest.php
+++ b/tests/MiniProgram/Broadcast/ClientTest.php
@@ -84,7 +84,7 @@ class ClientTest extends TestCase
     public function testGetGoodsWarehouse()
     {
         $client = $this->mockApiClient(Client::class);
-        $client->expects()->httpGet('wxa/business/getgoodswarehouse', ['goods_ids' => [1]])->andReturn('mock-result');
+        $client->expects()->httpPostJson('wxa/business/getgoodswarehouse', ['goods_ids' => [1]])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->getGoodsWarehouse([1]));
     }


### PR DESCRIPTION
之前腾讯官方文档不完善，被官方文档误导了，请求方式其实是POST