### PR TITLE
新增企业微信标签管理与客户群

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "easywechat-composer/easywechat-composer": "^1.1",
         "guzzlehttp/guzzle": "^6.2",
         "monolog/monolog": "^1.22 || ^2.0",
-        "overtrue/socialite": "dev-develop",
+        "overtrue/socialite": "~2.0",
         "pimple/pimple": "^3.0",
         "psr/simple-cache": "^1.0",
         "symfony/cache": "^3.3 || ^4.3 || ^5.0",

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "easywechat-composer/easywechat-composer": "^1.1",
         "guzzlehttp/guzzle": "^6.2",
         "monolog/monolog": "^1.22 || ^2.0",
-        "overtrue/socialite": "~2.0",
+        "overtrue/socialite": "dev-develop",
         "pimple/pimple": "^3.0",
         "psr/simple-cache": "^1.0",
         "symfony/cache": "^3.3 || ^4.3 || ^5.0",

--- a/src/Work/ExternalContact/Client.php
+++ b/src/Work/ExternalContact/Client.php
@@ -70,6 +70,26 @@ class Client extends BaseClient
         ]);
     }
 
+
+    /**
+     * 修改客户备注信息.
+     *
+     * @see https://work.weixin.qq.com/api/doc/90000/90135/92115
+     *
+     * @param array $data
+     *
+     * @return array|\EasyWeChat\Kernel\Support\Collection|object|\Psr\Http\Message\ResponseInterface|string
+     *
+     * @throws \EasyWeChat\Kernel\Exceptions\InvalidConfigException
+     */
+    public function remark(array $data)
+    {
+        return $this->httpPostJson('cgi-bin/externalcontact/remark',
+            $data
+        );
+    }
+
+
     /**
      * 获取离职成员的客户列表.
      *

--- a/src/Work/ExternalContact/Client.php
+++ b/src/Work/ExternalContact/Client.php
@@ -142,11 +142,7 @@ class Client extends BaseClient
      *
      * @see https://work.weixin.qq.com/api/doc/90000/90135/92120
      *
-     * @param int $statusFilter
-     * @param array $useridList
-     * @param array $partyidList
-     * @param int $offset
-     * @param int $limit
+     * @param array $params
      *
      * @return array|\EasyWeChat\Kernel\Support\Collection|object|\Psr\Http\Message\ResponseInterface|string
      *
@@ -154,21 +150,10 @@ class Client extends BaseClient
      * @throws \GuzzleHttp\Exception\GuzzleException
      */
 
-    public function getGroupChatList(int $statusFilter=0,array $useridList=[],array $partyidList=[],int $offset=0,int $limit=100){
-
-        $params = [
-            "status_filter"=> $statusFilter,
-            "owner_filter"=> [
-                "userid_list"=> $useridList,
-                "partyid_list"=> $partyidList
-            ],
-            "offset" => $offset,
-            "limit" => $limit
-        ];
+    public function getGroupChats(array $params)
+    {
         return $this->httpPostJson('cgi-bin/externalcontact/groupchat/list', $params);
     }
-
-
 
     /**
      * 获取客户群详情.
@@ -183,15 +168,14 @@ class Client extends BaseClient
      * @throws \GuzzleHttp\Exception\GuzzleException
      */
 
-    public function getGroupChat(string $chatId){
-
+    public function getGroupChat(string $chatId)
+    {
         $params = [
             'chat_id' => $chatId
         ];
 
         return $this->httpPostJson('cgi-bin/externalcontact/groupchat/get', $params);
     }
-
 
     /**
      * 获取企业标签库.
@@ -206,8 +190,8 @@ class Client extends BaseClient
      * @throws \GuzzleHttp\Exception\GuzzleException
      */
 
-    public function getCorpTagList(array $tagIds=[]){
-
+    public function getCorpTags(array $tagIds = [])
+    {
         $params = [
             'tag_id' => $tagIds
         ];
@@ -222,10 +206,7 @@ class Client extends BaseClient
      *
      * @see https://work.weixin.qq.com/api/doc/90000/90135/92117#添加企业客户标签
      *
-     * @param string $groupId
-     * @param string $groupName
-     * @param $order $order
-     * @param array $tags
+     * @param array $params
      *
      * @return array|\EasyWeChat\Kernel\Support\Collection|object|\Psr\Http\Message\ResponseInterface|string
      *
@@ -233,15 +214,8 @@ class Client extends BaseClient
      * @throws \GuzzleHttp\Exception\GuzzleException
      */
 
-    public function addCorpTag(string $groupId='',string $groupName,int $order=1,array $tags){
-
-        $params = [
-            "group_id" => $groupId,
-            "group_name" => $groupName,
-            "order" => $order,
-            "tag" => $tags
-        ];
-
+    public function addCorpTag(array $params)
+    {
         return $this->httpPostJson('cgi-bin/externalcontact/add_corp_tag', $params);
     }
 
@@ -253,7 +227,7 @@ class Client extends BaseClient
      *
      * @param string $id
      * @param string $name
-     * @param $order $order
+     * @param int $order
      *
      * @return array|\EasyWeChat\Kernel\Support\Collection|object|\Psr\Http\Message\ResponseInterface|string
      *
@@ -261,8 +235,8 @@ class Client extends BaseClient
      * @throws \GuzzleHttp\Exception\GuzzleException
      */
 
-    public function editCorpTag(string $id,string $name,int $order=1){
-
+    public function updateCorpTag(string $id, string $name, int $order = 1)
+    {
         $params = [
             "id" => $id,
             "name" => $name,
@@ -287,8 +261,8 @@ class Client extends BaseClient
      * @throws \GuzzleHttp\Exception\GuzzleException
      */
 
-    public function delCorpTag(array $tagId,array $groupId){
-
+    public function deleteCorpTag(array $tagId, array $groupId)
+    {
         $params = [
             "tag_id" => $tagId,
             "group_id" => $groupId,
@@ -303,10 +277,7 @@ class Client extends BaseClient
      *
      * @see https://work.weixin.qq.com/api/doc/90000/90135/92118
      *
-     * @param string $userId
-     * @param string $externalUserid
-     * @param array $addTag
-     * @param array $removeTag
+     * @param array $params
      *
      * @return array|\EasyWeChat\Kernel\Support\Collection|object|\Psr\Http\Message\ResponseInterface|string
      *
@@ -314,15 +285,8 @@ class Client extends BaseClient
      * @throws \GuzzleHttp\Exception\GuzzleException
      */
 
-    public function markTag(string $userId,string $externalUserid,array $addTag=[],array $removeTag=[]){
-
-        $params = [
-            "userid" => $userId,
-            "external_userid" => $externalUserid,
-            "add_tag" => $addTag,
-            "remove_tag" => $removeTag,
-        ];
-
+    public function markTags(array $params)
+    {
         return $this->httpPostJson('cgi-bin/externalcontact/mark_tag', $params);
     }
 

--- a/src/Work/ExternalContact/Client.php
+++ b/src/Work/ExternalContact/Client.php
@@ -172,7 +172,145 @@ class Client extends BaseClient
 
     public function getGroupChat(string $chatId){
 
-        return $this->httpPostJson('cgi-bin/externalcontact/groupchat/get', $data);
+        $params = [
+            'chat_id' => $chatId
+        ];
+
+        return $this->httpPostJson('cgi-bin/externalcontact/groupchat/get', $params);
+    }
+
+
+    /**
+     * 获取企业标签库.
+     *
+     * @see https://work.weixin.qq.com/api/doc/90000/90135/92117#获取企业标签库
+     *
+     * @param array $tagIds
+     *
+     * @return array|\EasyWeChat\Kernel\Support\Collection|object|\Psr\Http\Message\ResponseInterface|string
+     *
+     * @throws \EasyWeChat\Kernel\Exceptions\InvalidConfigException
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+
+    public function getCorpTagList(array $tagIds=[]){
+
+        $params = [
+            'tag_id' => $tagIds
+        ];
+
+        return $this->httpPostJson('cgi-bin/externalcontact/get_corp_tag_list', $params);
+    }
+
+
+
+    /**
+     * 添加企业客户标签.
+     *
+     * @see https://work.weixin.qq.com/api/doc/90000/90135/92117#添加企业客户标签
+     *
+     * @param string $groupId
+     * @param string $groupName
+     * @param $order $order
+     * @param array $tags
+     *
+     * @return array|\EasyWeChat\Kernel\Support\Collection|object|\Psr\Http\Message\ResponseInterface|string
+     *
+     * @throws \EasyWeChat\Kernel\Exceptions\InvalidConfigException
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+
+    public function addCorpTag(string $groupId='',string $groupName,int $order=1,array $tags){
+
+        $params = [
+            "group_id" => $groupId,
+            "group_name" => $groupName,
+            "order" => $order,
+            "tag" => $tags
+        ];
+
+        return $this->httpPostJson('cgi-bin/externalcontact/add_corp_tag', $params);
+    }
+
+
+    /**
+     * 编辑企业客户标签.
+     *
+     * @see https://work.weixin.qq.com/api/doc/90000/90135/92117#编辑企业客户标签
+     *
+     * @param string $id
+     * @param string $name
+     * @param $order $order
+     *
+     * @return array|\EasyWeChat\Kernel\Support\Collection|object|\Psr\Http\Message\ResponseInterface|string
+     *
+     * @throws \EasyWeChat\Kernel\Exceptions\InvalidConfigException
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+
+    public function editCorpTag(string $id,string $name,int $order=1){
+
+        $params = [
+            "id" => $id,
+            "name" => $name,
+            "order" => $order,
+        ];
+
+        return $this->httpPostJson('cgi-bin/externalcontact/edit_corp_tag', $params);
+    }
+
+
+    /**
+     * 删除企业客户标签.
+     *
+     * @see https://work.weixin.qq.com/api/doc/90000/90135/92117#删除企业客户标签
+     *
+     * @param array $tagId
+     * @param array $groupId
+     *
+     * @return array|\EasyWeChat\Kernel\Support\Collection|object|\Psr\Http\Message\ResponseInterface|string
+     *
+     * @throws \EasyWeChat\Kernel\Exceptions\InvalidConfigException
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+
+    public function delCorpTag(array $tagId,array $groupId){
+
+        $params = [
+            "tag_id" => $tagId,
+            "group_id" => $groupId,
+        ];
+
+        return $this->httpPostJson('cgi-bin/externalcontact/del_corp_tag', $params);
+    }
+
+
+    /**
+     * 编辑客户企业标签.
+     *
+     * @see https://work.weixin.qq.com/api/doc/90000/90135/92118
+     *
+     * @param string $userId
+     * @param string $externalUserid
+     * @param array $addTag
+     * @param array $removeTag
+     *
+     * @return array|\EasyWeChat\Kernel\Support\Collection|object|\Psr\Http\Message\ResponseInterface|string
+     *
+     * @throws \EasyWeChat\Kernel\Exceptions\InvalidConfigException
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+
+    public function markTag(string $userId,string $externalUserid,array $addTag=[],array $removeTag=[]){
+
+        $params = [
+            "userid" => $userId,
+            "external_userid" => $externalUserid,
+            "add_tag" => $addTag,
+            "remove_tag" => $removeTag,
+        ];
+
+        return $this->httpPostJson('cgi-bin/externalcontact/mark_tag', $params);
     }
 
 

--- a/src/Work/ExternalContact/Client.php
+++ b/src/Work/ExternalContact/Client.php
@@ -142,7 +142,11 @@ class Client extends BaseClient
      *
      * @see https://work.weixin.qq.com/api/doc/90000/90135/92120
      *
-     * @param array $data
+     * @param int $statusFilter
+     * @param array $useridList
+     * @param array $partyidList
+     * @param int $offset
+     * @param int $limit
      *
      * @return array|\EasyWeChat\Kernel\Support\Collection|object|\Psr\Http\Message\ResponseInterface|string
      *
@@ -150,9 +154,18 @@ class Client extends BaseClient
      * @throws \GuzzleHttp\Exception\GuzzleException
      */
 
-    public function getGroupChatList(array $data){
+    public function getGroupChatList(int $statusFilter=0,array $useridList=[],array $partyidList=[],int $offset=0,int $limit=100){
 
-        return $this->httpPostJson('cgi-bin/externalcontact/groupchat/list', $data);
+        $params = [
+            "status_filter"=> $statusFilter,
+            "owner_filter"=> [
+                "userid_list"=> $useridList,
+                "partyid_list"=> $partyidList
+            ],
+            "offset" => $offset,
+            "limit" => $limit
+        ];
+        return $this->httpPostJson('cgi-bin/externalcontact/groupchat/list', $params);
     }
 
 
@@ -314,5 +327,5 @@ class Client extends BaseClient
     }
 
 
-    
+
 }

--- a/src/Work/ExternalContact/Client.php
+++ b/src/Work/ExternalContact/Client.php
@@ -135,4 +135,45 @@ class Client extends BaseClient
 
         return $this->httpPostJson('cgi-bin/externalcontact/transfer', $params);
     }
+
+
+    /**
+     * 获取客户群列表.
+     *
+     * @see https://work.weixin.qq.com/api/doc/90000/90135/92120
+     *
+     * @param array $data
+     *
+     * @return array|\EasyWeChat\Kernel\Support\Collection|object|\Psr\Http\Message\ResponseInterface|string
+     *
+     * @throws \EasyWeChat\Kernel\Exceptions\InvalidConfigException
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+
+    public function getGroupChatList(array $data){
+
+        return $this->httpPostJson('cgi-bin/externalcontact/groupchat/list', $data);
+    }
+
+
+
+    /**
+     * 获取客户群详情.
+     *
+     * @see https://work.weixin.qq.com/api/doc/90000/90135/92122
+     *
+     * @param string $chatId
+     *
+     * @return array|\EasyWeChat\Kernel\Support\Collection|object|\Psr\Http\Message\ResponseInterface|string
+     *
+     * @throws \EasyWeChat\Kernel\Exceptions\InvalidConfigException
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+
+    public function getGroupChat(string $chatId){
+
+        return $this->httpPostJson('cgi-bin/externalcontact/groupchat/get', $data);
+    }
+
+
 }

--- a/src/Work/ExternalContact/Client.php
+++ b/src/Work/ExternalContact/Client.php
@@ -314,4 +314,5 @@ class Client extends BaseClient
     }
 
 
+    
 }


### PR DESCRIPTION
### 新增接口如下
- 获取客户群列表
- 获取客户群详情
- 获取企业标签库
- 添加企业客户标签
- 编辑企业客户标签
- 删除企业客户标签
- 编辑客户企业标签

> 注意: 对于添加/删除/编辑企业客户标签接口，目前仅支持使用“客户联系”secret所获取的accesstoken来调用。
企业微信官方原文 https://work.weixin.qq.com/api/doc/90000/90135/92117

获取企业标签库 与 编辑客户企业标签 无需另外的secret
