### PR TITLE
优化 submitAudit 方法

### DIFF
--- a/src/OpenPlatform/Authorizer/MiniProgram/Code/Client.php
+++ b/src/OpenPlatform/Authorizer/MiniProgram/Code/Client.php
@@ -77,7 +77,7 @@ class Client extends BaseClient
     }
 
     /**
-     * @param array       $itemList
+     * @param array $data
      * @param string|null $feedbackInfo
      * @param string|null $feedbackStuff
      *
@@ -86,10 +86,14 @@ class Client extends BaseClient
      * @throws \EasyWeChat\Kernel\Exceptions\InvalidConfigException
      * @throws \GuzzleHttp\Exception\GuzzleException
      */
-    public function submitAudit(array $itemList, string $feedbackInfo = null, string $feedbackStuff = null)
+    public function submitAudit(array $data, string $feedbackInfo = null, string $feedbackStuff = null)
     {
+        if (isset($data['item_list'])) {
+            return $this->httpPostJson('wxa/submit_audit', $data);
+        }
+
         return $this->httpPostJson('wxa/submit_audit', [
-            'item_list' => $itemList,
+            'item_list' => $data,
             'feedback_info' => $feedbackInfo,
             'feedback_stuff' => $feedbackStuff,
         ]);

--- a/tests/OpenPlatform/Authorizer/MiniProgram/Code/ClientTest.php
+++ b/tests/OpenPlatform/Authorizer/MiniProgram/Code/ClientTest.php
@@ -63,6 +63,10 @@ class ClientTest extends TestCase
         $client = $this->mockApiClient(Client::class, [], new ServiceContainer(['app_id' => 'app-id']));
         $client->expects()->httpPostJson('wxa/submit_audit', ['item_list' => ['foo', 'bar'], 'feedback_info' => 'foo', 'feedback_stuff' => 'foo'])->andReturn('mock-result');
         $this->assertSame('mock-result', $client->submitAudit(['foo', 'bar'], 'foo', 'foo'));
+
+        $data = ['item_list' => ['foo', 'bar'], 'feedback_info' => 'foo', 'feedback_stuff' => 'foo', 'preview_info' => 'bar'];
+        $client->expects()->httpPostJson('wxa/submit_audit', $data)->andReturn('mock-result');
+        $this->assertSame('mock-result', $client->submitAudit($data));
     }
 
     public function testGetAuditStatus()


### PR DESCRIPTION
Fixed #1864 

[小程序代发布](https://developers.weixin.qq.com/doc/oplatform/Third-party_Platforms/Mini_Programs/code/submit_audit.html) 接口新增了几个可选参数，为了避免  submitAudit 方法参数签名过长，所以增加数组传参的方式，并兼容旧版本的使用方法。

 旧版本使用方法：

```
$itemList = ['foo', 'bar'];
$feedbackInfo = 'foo';
$feedbackStuff = 'foo';

$app->code->submitAudit($itemList, $feedbackInfo, $feedbackStuff);
```

修改后的使用方法：

```
$data = [
    'item_list' => ['foo', 'bar'],
    'feedback_info' => 'foo',
    'feedback_stuff' => 'foo',
    'preview_info' => 'bar',
    // more options...
];

$app->code->submitAudit($data);
```