### PR TITLE
Jssdk adds openTagList configuration item.

### DIFF
--- a/src/BasicService/Jssdk/Client.php
+++ b/src/BasicService/Jssdk/Client.php
@@ -41,19 +41,21 @@ class Client extends BaseClient
      * Get config json for jsapi.
      *
      * @param array $jsApiList
-     * @param bool  $debug
-     * @param bool  $beta
-     * @param bool  $json
+     * @param bool $debug
+     * @param bool $beta
+     * @param bool $json
+     * @param array $openTagList
      *
      * @return array|string
      *
+     * @throws RuntimeException
+     * @throws \EasyWeChat\Kernel\Exceptions\InvalidArgumentException
      * @throws \EasyWeChat\Kernel\Exceptions\InvalidConfigException
      * @throws \Psr\SimpleCache\InvalidArgumentException
-     * @throws \EasyWeChat\Kernel\Exceptions\RuntimeException
      */
-    public function buildConfig(array $jsApiList, bool $debug = false, bool $beta = false, bool $json = true)
+    public function buildConfig(array $jsApiList, bool $debug = false, bool $beta = false, bool $json = true, array $openTagList = [])
     {
-        $config = array_merge(compact('debug', 'beta', 'jsApiList'), $this->configSignature());
+        $config = array_merge(compact('debug', 'beta', 'jsApiList', 'openTagList'), $this->configSignature());
 
         return $json ? json_encode($config) : $config;
     }
@@ -64,16 +66,18 @@ class Client extends BaseClient
      * @param array $apis
      * @param bool  $debug
      * @param bool  $beta
+     * @param array $openTagList
      *
      * @return array
      *
+     * @throws RuntimeException
+     * @throws \EasyWeChat\Kernel\Exceptions\InvalidArgumentException
      * @throws \EasyWeChat\Kernel\Exceptions\InvalidConfigException
      * @throws \Psr\SimpleCache\InvalidArgumentException
-     * @throws \EasyWeChat\Kernel\Exceptions\RuntimeException
      */
-    public function getConfigArray(array $apis, bool $debug = false, bool $beta = false)
+    public function getConfigArray(array $apis, bool $debug = false, bool $beta = false, array $openTagList = [])
     {
-        return $this->buildConfig($apis, $debug, $beta, false);
+        return $this->buildConfig($apis, $debug, $beta, false, $openTagList);
     }
 
     /**

--- a/tests/BasicService/Jssdk/ClientTest.php
+++ b/tests/BasicService/Jssdk/ClientTest.php
@@ -28,6 +28,7 @@ class ClientTest extends TestCase
         $this->assertArrayHasKey('beta', $config);
         $this->assertArrayHasKey('jsApiList', $config);
         $this->assertArrayHasKey('foo', $config);
+        $this->assertArrayHasKey('openTagList', $config);
 
         $this->assertFalse($config['debug']);
         $this->assertFalse($config['beta']);
@@ -35,22 +36,24 @@ class ClientTest extends TestCase
         $this->assertSame('bar', $config['foo']);
 
         // beta: true, debug: true, json:false
-        $config = $client->buildConfig(['api1', 'api2'], true, true, false);
+        $config = $client->buildConfig(['api1', 'api2'], true, true, false, ['foo', 'bar']);
         $this->assertArrayHasKey('debug', $config);
         $this->assertArrayHasKey('beta', $config);
         $this->assertArrayHasKey('jsApiList', $config);
         $this->assertArrayHasKey('foo', $config);
+        $this->assertArrayHasKey('openTagList', $config);
 
         $this->assertTrue($config['debug']);
         $this->assertTrue($config['beta']);
         $this->assertSame(['api1', 'api2'], $config['jsApiList']);
         $this->assertSame('bar', $config['foo']);
+        $this->assertSame(['foo', 'bar'], $config['openTagList']);
     }
 
     public function testGetConfigArray()
     {
         $client = $this->mockApiClient(Client::class, 'buildConfig');
-        $client->expects()->buildConfig(['api1', 'api2'], true, true, false)->andReturn('mock-result');
+        $client->expects()->buildConfig(['api1', 'api2'], true, true, false, [])->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->getConfigArray(['api1', 'api2'], true, true));
     }


### PR DESCRIPTION
Fixed #1917 

[https://developers.weixin.qq.com/doc/offiaccount/OA_Web_Apps/Wechat_Open_Tag.html](https://developers.weixin.qq.com/doc/offiaccount/OA_Web_Apps/Wechat_Open_Tag.html)

Jssdk 新增 openTagList 配置项：

```
wx.config({
  debug: true, // 开启调试模式,调用的所有api的返回值会在客户端alert出来，若要查看传入的参数，可以在pc端打开，参数信息会通过log打出，仅在pc端时才会打印
  appId: '', // 必填，公众号的唯一标识
  timestamp: , // 必填，生成签名的时间戳
  nonceStr: '', // 必填，生成签名的随机串
  signature: '',// 必填，签名
  jsApiList: [], // 必填，需要使用的JS接口列表
  openTagList: [] // 可选，需要使用的开放标签列表，例如['wx-open-launch-app']
});
```