### PR TITLE
解绑小程序体验者操作的接口支持"微信号"（wechatid）与"人员对应的唯一字符串"(userstr)

### DIFF
--- a/src/OpenPlatform/Authorizer/MiniProgram/Tester/Client.php
+++ b/src/OpenPlatform/Authorizer/MiniProgram/Tester/Client.php
@@ -48,15 +48,17 @@ class Client extends BaseClient
      * @throws \EasyWeChat\Kernel\Exceptions\InvalidConfigException
      * @throws \GuzzleHttp\Exception\GuzzleException
      */
-    public function unbind(string $wechatId,string $userStr='')
-    {
-        if ($userStr)
-            return $this->httpPostJson('wxa/unbind_tester', [
-                'userstr' => $userStr,
+    public function unbind(string $wechatId = null,  string $userStr = null)
+    {   
+        return $this->httpPostJson('wxa/unbind_tester', [
+                ($userStr ? 'userstr' : 'wechatid') => $userStr ?? $wechatId,
             ]);
-        else
-            return $this->httpPostJson('wxa/unbind_tester', [
-                'wechatid' => $wechatId,
+    }
+    
+    public function unbindWithUserStr(string $userStr)
+    {   
+        return $this->httpPostJson('wxa/unbind_tester', [
+                'userstr' => $userStr,
             ]);
     }
 

--- a/src/OpenPlatform/Authorizer/MiniProgram/Tester/Client.php
+++ b/src/OpenPlatform/Authorizer/MiniProgram/Tester/Client.php
@@ -41,17 +41,22 @@ class Client extends BaseClient
      * 解绑小程序体验者.
      *
      * @param string $wechatId
+     * @param string $userStr
      *
      * @return array|\EasyWeChat\Kernel\Support\Collection|object|\Psr\Http\Message\ResponseInterface|string
      *
      * @throws \EasyWeChat\Kernel\Exceptions\InvalidConfigException
-     * @throws \GuzzleHttp\Exception\GuzzleException
      */
-    public function unbind(string $wechatId)
+    public function unbind(string $wechatId,string $userStr='')
     {
-        return $this->httpPostJson('wxa/unbind_tester', [
-            'wechatid' => $wechatId,
-        ]);
+        if ($userStr)
+            return $this->httpPostJson('wxa/unbind_tester', [
+                'userstr' => $userStr,
+            ]);
+        else
+            return $this->httpPostJson('wxa/unbind_tester', [
+                'wechatid' => $wechatId,
+            ]);
     }
 
     /**

--- a/src/OpenPlatform/Authorizer/MiniProgram/Tester/Client.php
+++ b/src/OpenPlatform/Authorizer/MiniProgram/Tester/Client.php
@@ -46,6 +46,7 @@ class Client extends BaseClient
      * @return array|\EasyWeChat\Kernel\Support\Collection|object|\Psr\Http\Message\ResponseInterface|string
      *
      * @throws \EasyWeChat\Kernel\Exceptions\InvalidConfigException
+     * @throws \GuzzleHttp\Exception\GuzzleException
      */
     public function unbind(string $wechatId,string $userStr='')
     {


### PR DESCRIPTION
在第三方平台中，对授权小程序进行解绑小程序体验者操作的接口支持"微信号"（wechatid）与"人员对应的唯一字符串"(userstr)参数，userstr 和 wechatid 填写其中一个即可。本次PulRequest增加了对userstr参数的支持，非必填，填了就优先使用userstr，可以向前兼用，详见微信第三方平台文档https://developers.weixin.qq.com/doc/oplatform/Third-party_Platforms/Mini_Programs/unbind_tester.html