### PR TITLE
[Pay] 增加V3微信支付调用方法

### DIFF
--- a/src/Pay/Application.php
+++ b/src/Pay/Application.php
@@ -9,8 +9,12 @@ use EasyWeChat\Kernel\Traits\InteractWithConfig;
 use EasyWeChat\Kernel\Contracts\Config as ConfigInterface;
 use EasyWeChat\Kernel\Traits\InteractWithHttpClient;
 use EasyWeChat\Kernel\Traits\InteractWithServerRequest;
+use EasyWeChat\Pay\V3\Api;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
+/**
+ * @property-read Api v3
+ */
 class Application implements \EasyWeChat\Pay\Contracts\Application
 {
     use InteractWithConfig;
@@ -99,5 +103,12 @@ class Application implements \EasyWeChat\Pay\Contracts\Application
     public function getConfig(): ConfigInterface
     {
         return $this->config;
+    }
+
+    public function __get($name)
+    {
+        if ($name === "v3") {
+            return new Api($this->getMerchant(), $this->getClient());
+        }
     }
 }

--- a/src/Pay/V3/Api.php
+++ b/src/Pay/V3/Api.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace EasyWeChat\Pay\V3;
+
+/**
+ * @property-read Native native
+ */
+class Api extends BaseProvideV3
+{
+    public function __get(string $name)
+    {
+        $apis = ['native'];
+        if (in_array($name, $apis)) {
+            $class = 'EasyWeChat\\Pay\V3\\'.ucwords($name);
+            return new $class($this->merchant, $this->client);
+        }
+    }
+}

--- a/src/Pay/V3/BaseProvideV3.php
+++ b/src/Pay/V3/BaseProvideV3.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace EasyWeChat\Pay\V3;
+
+use EasyWeChat\Pay\Merchant;
+use EasyWeChat\Pay\WechatPayException;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+class BaseProvideV3
+{
+    public function __construct(
+        protected Merchant $merchant,
+        protected HttpClientInterface $client
+    ) {
+    }
+
+    protected function getResult(ResponseInterface $response)
+    {
+        $code = $response->getStatusCode();
+        if ($code !== 200) {
+            $content = json_decode($response->getContent(false), true);
+            if (JSON_ERROR_NONE === json_last_error()) {
+                throw new WechatPayException($content['message'] ?? '', $code);
+            }
+        }
+        return $response->toArray(true);
+    }
+
+    protected function getMerchantId(): string
+    {
+        return (string)$this->merchant->getMerchantId();
+    }
+}

--- a/src/Pay/V3/Native.php
+++ b/src/Pay/V3/Native.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace EasyWeChat\Pay\V3;
+
+class Native extends BaseProvideV3
+{
+    public function pay(
+        string $appid,
+        string $description,
+        string $out_trade_no,
+        string $notify_url,
+        int $total,
+        string $currency = "CNY",
+        array $other = []
+    ): array {
+        $data = [
+            'appid' => $appid,
+            'mchid' => $this->getMerchantId(),
+            'description' => $description,
+            'out_trade_no' => $out_trade_no,
+            'notify_url' => $notify_url,
+            'amount' => [
+                'total' => $total,
+                'currency' => $currency
+            ]
+        ];
+
+        $data = array_merge($data, $other);
+
+        $response = $this->client->post("pay/transactions/native", [
+            'json' => $data
+        ]);
+
+        return $this->getResult($response);
+    }
+
+    public function id(string $transaction_id)
+    {
+        $mch_id = $this->getMerchantId();
+
+        $response = $this->client->get("pay/transactions/id/".$transaction_id."?mchid=".$mch_id);
+
+        return $this->getResult($response);
+    }
+}

--- a/src/Pay/WechatPayException.php
+++ b/src/Pay/WechatPayException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace EasyWeChat\Pay;
+
+class WechatPayException extends \Exception
+{
+}


### PR DESCRIPTION
目前的微信支付V3需要手动填写地址等，所以想着更方便的改进一下。

先写了一个下单和查单，如果此写法通过，我将补充完毕剩下的接口。