### PR TITLE
Fix formatting in index.md for suite_secret

### DIFF
--- a/docs/src/6.x/work/index.md
+++ b/docs/src/6.x/work/index.md
@@ -15,7 +15,7 @@ $config = [
   'aes_key' => '35d4687abb469072a29f1c242xxxxxx',
   // 记得配置suite_id，不然suite_ticket不能自动存储
   'suite_id' => 'ww9f1388bf664xxxxx',
-  'suite_secret' => 'reuXvCX_5FhDVm_sOslJEHRVxxxxxxx'
+  'suite_secret' => 'reuXvCX_5FhDVm_sOslJEHRVxxxxxxx',
 
   /**
    * 接口请求相关配置，超时时间等，具体可用参数请参考：


### PR DESCRIPTION
示例代码缺少一个逗号, 导致复制粘贴到IDE后报错, 不利于新手